### PR TITLE
Make data/heap/resizer public

### DIFF
--- a/std/data/heap.kk
+++ b/std/data/heap.kk
@@ -276,7 +276,7 @@ fun get-grandparent( i : int ) : maybe<int>
     Just( i / 4 )
 
 // Internal base function for dictating how to resize the vector buffer.
-fun resizer( size : int ) : int
+pub fun resizer( size : int ) : int
   if size == 0 then
     1
   else


### PR DESCRIPTION
Without this modifier data/heap/insert can't resolve the `resizer` implicit parameter