### PR TITLE
Break up test functionality into `test` / `expect` effects, and introduce test reporter functionality

### DIFF
--- a/examples/test/plain-reporter.kk
+++ b/examples/test/plain-reporter.kk
@@ -1,0 +1,6 @@
+import std/test
+
+fun main()
+  with run-tests(reporter = plain-reporter)
+  test("OK")
+    ()

--- a/examples/test/test-suite.kk
+++ b/examples/test/test-suite.kk
@@ -1,0 +1,23 @@
+import std/test
+
+fun main()
+  with run-tests()
+  group("Basics")
+    test("Successful")
+      ()
+    with group("A subgroup")
+    test("Returns continue tests")
+      val res = expect-result(1)
+                  2
+      hint("Continued!")
+      expect(2)
+        1 + res
+      expect(2)
+        1
+  group("Other")
+    test("Wrong expect")
+      expect(1)
+        2
+    test("Additional info")
+      expect(1, details="Really expected 1!")
+        throw("Some error somewhere")

--- a/std/test.kk
+++ b/std/test.kk
@@ -8,4 +8,5 @@
 module std/test
 pub import std/test/test
 pub import std/test/bench
+pub import std/test/report
 pub import std/test/run

--- a/std/test.kk
+++ b/std/test.kk
@@ -8,3 +8,4 @@
 module std/test
 pub import std/test/test
 pub import std/test/bench
+pub import std/test/run

--- a/std/test/report.kk
+++ b/std/test/report.kk
@@ -1,0 +1,93 @@
+module std/test/report
+import std/test/test
+import std/pretty/printer
+
+pub fun report-scope-once(reported-scopes: ref<global, list<int>>, scope: maybe<test-scope>, report: (test-scope) -> <st<global>,div|e> ()): <st<global>,div|e> ()
+  match scope
+    Nothing -> ()
+    Just(scope) ->
+      report-scope-once(reported-scopes, scope.parent, report)
+      val reported = !reported-scopes
+      if reported.find(fn(id) -> id == scope.scope-id).is-nothing then
+        reported-scopes := Cons(scope.scope-id, reported)
+        report(scope)
+
+pub fun plain-reporter(action: () -> <test-report,io|e> ()): <io|e> ()
+  val reported-scopes = ref([])
+
+  with handler <test-report>
+    fun report-skipped(test)
+      ()
+
+    fun report-start(test)
+      val infomsg = test.scope.indentation ++ test.name
+      report-scope-once(reported-scopes, test.scope) fn(scope)
+        println(scope.parent.indentation ++ scope.scope-name ++ ":")
+      println(infomsg ++ "(" ++ test.location.show ++ ")...")
+
+    fun report-hint(test, hint)
+      println(test.scope.indentation ++ hint)
+
+    fun report-end(test, failures: int)
+      val infomsg = test.scope.indentation ++ test.name ++ "(" ++ test.location.show ++ "):"
+      val result = if failures == 0 then "OK" else "FAIL"
+      println(infomsg ++ " " ++ result)
+
+    fun report-failure(test: test-identity, failed-expectation)
+      println(test.scope.indentation() ++ "  " ++ failed-expectation.show-failed())
+
+    fun report-summary(summary: suite-summary)
+      println(summary.failures.show ++ " failures, " ++ summary.successes.show ++ " successes")
+
+  mask<local>(action)
+
+pub fun color-reporter(action: () -> <test-report,io|e> ()): <io|e> ()
+  val reported-scopes = ref([])
+  var failed-test-names := []
+  var hint-buffer-rev := []
+
+  with ansi-printer
+  with handler <test-report>
+    fun report-skipped(test)
+      ()
+
+    fun report-start(test)
+      hint-buffer-rev := []
+      report-scope-once(reported-scopes, test.scope) fn(scope)
+        println-colored(scope.parent.indentation ++ scope.scope-name ++ ":", Cyan)
+      println-colored(test.scope.indentation ++ test.name ++ "(" ++ test.location.show ++ ")...", Cyan)
+
+    fun report-hint(test, hint)
+      // accumulate and only output on failure
+      hint-buffer-rev := Cons(hint, hint-buffer-rev)
+
+    fun report-end(test, failures: int)
+      if failures == 0 then
+        println-colored(test.scope.indentation ++ "- ok", Green)
+      else
+        hint-buffer-rev.reverse.foreach fn(hint)
+          println-colored(test.scope.indentation ++ hint, Yellow)
+
+        println-colored(test.scope.indentation ++ "- failed\n", Red)
+        failed-test-names := Cons(test.full-name, failed-test-names)
+
+    fun report-failure(test: test-identity, failed-expectation)
+      println-colored(test.scope.indentation() ++ failed-expectation.show-failed(), Red)
+
+    fun report-summary(summary: suite-summary)
+      val color = if summary.failures > 0 then Red else Green
+      println-colored(
+        summary.failures.show ++ " failures, " ++ summary.successes.show ++ " successes"
+        ++ (if summary.skipped > 0 then " (" ++ summary.skipped.show ++ " skipped)" else "")
+      , color)
+
+      if summary.failures > 0 then
+        println-colored("\nFailed tests:", Red)
+        failed-test-names.foreach fn(name)
+          println-colored(" - " ++ name, Red)
+
+  with mask<printer>
+  with mask<coloredPrinter>
+  with mask<local>
+  action()
+

--- a/std/test/run.kk
+++ b/std/test/run.kk
@@ -5,8 +5,8 @@
    use this file except in compliance with the License. A copy of the License
    can be found in the LICENSE file at the root of this distribution.
 ----------------------------------------------------------------------------*/
-module test/run
-import test/test
+module std/test/run
+import std/test/test
 import std/os/env
 import std/os/flags
 
@@ -48,15 +48,23 @@ fun testopts/should-include(opts: testopts, test: test-identity)
       patterns.any fn(pattern)
         test.full-name.contains(pattern)
 
-fun execute-tests(opts: testopts, tests: list<test-case<io>>): <test-report,io> ()
-  tests.foreach fn(test)
-    // TODO: run async tests in parallel
-    val tid = test.identity
-    if not(opts.should-include(tid)) then
-      report-skipped(tid)
-      return ()
-    test.execute()
 
+// TODO: use core/std/exit after https://github.com/koka-lang/koka/pull/703 is released
+extern exit(i: int): io-noexn ()
+  c inline "exit(kk_integer_clamp32(#1, kk_context()))"
+  js inline "throw(`Exited with code: ${#1}`)"
+
+fun execute-tests(opts: testopts, tests: list<test-case<io>>): <test-report,io> ()
+  var summary := suite-summary()
+  tests.foreach fn(test)
+    val tid = test.identity
+    if opts.should-include(tid) then
+      summary := summary.execute(test)
+    else
+      report-skipped(tid)
+  report-summary(summary)
+  if summary.any-failures then
+    exit(1)
 
 // Parse commandline arguments
 pub fun parse-opts(args = get-args()): io testopts
@@ -73,7 +81,8 @@ pub fun parse-opts(args = get-args()): io testopts
     throw("Invalid options")
   opts(includes = filter-from(remainder))
 
-// Main entrypoint for running tests. Parses CLI arguments and runs the relevant tests
+// Main entrypoint for running tests. Parses CLI arguments and runs the relevant tests.
+// Exits the process with a nonzero exit code if any tests fail.
 // TODO: extend this to discover tests across multiple files
 pub fun run-tests(f: () -> <test,io> (), reporter: test-reporter<io> = color-reporter): io ()
   val opts = parse-opts()
@@ -88,29 +97,3 @@ pub fun run-tests(f: () -> <test,io> (), reporter: test-reporter<io> = color-rep
         println(t.identity.full-name)
 
 // Some simple examples
-fun main(): io ()
-  // custom reporter
-  run-tests(reporter = plain-reporter)
-    test("OK")
-      ()
-  println("----")
-
-  // default color-reporter
-  with run-tests()
-  group("Basics")
-    with group("A subgroup")
-    test("Returns continue tests")
-      val res = expect-result(1)
-                  2
-      hint("Continued!")
-      expect(2)
-        1 + res
-      expect(2)
-        1
-  group("Other")
-    test("Wrong expect")
-      expect(1)
-        2
-    test("Additional info")
-      expect(1, details="Really expected 1!")
-        throw("Some error somewhere")

--- a/std/test/run.kk
+++ b/std/test/run.kk
@@ -1,0 +1,116 @@
+/*----------------------------------------------------------------------------
+   Copyright 2025, Koka-Community Authors
+
+   Licensed under the MIT License ("The License"). You may not
+   use this file except in compliance with the License. A copy of the License
+   can be found in the LICENSE file at the root of this distribution.
+----------------------------------------------------------------------------*/
+module test/run
+import test/test
+import std/os/env
+import std/os/flags
+
+type test-action
+  Run
+  List
+
+fun test-action/show(x: test-action) : string
+  match x
+    Run -> "Run"
+    List -> "List"
+
+pub value type test-filter
+  All
+  Include(patterns: list<string>)
+
+fun test-filter/show(x: test-filter) : string
+  match x
+    All -> "*"
+    Include(p) -> "Include(" ++ p.show ++")"
+
+fun filter-from(args: list<string>)
+  if args.is-nil then
+    All
+  else
+    Include(args)
+
+value struct testopts
+  includes: test-filter = All
+  action: test-action = Run
+
+pub fun testopts/show(opts: testopts) : string
+  "Testopts("++opts.includes.show ++ ", " ++ opts.action.show ++ ")"
+
+fun testopts/should-include(opts: testopts, test: test-identity)
+  match opts.includes
+    All -> True
+    Include(patterns) ->
+      patterns.any fn(pattern)
+        test.full-name.contains(pattern)
+
+fun execute-tests(opts: testopts, tests: list<test-case<io>>): <test-report,io> ()
+  tests.foreach fn(test)
+    // TODO: run async tests in parallel
+    val tid = test.identity
+    if not(opts.should-include(tid)) then
+      report-skipped(tid)
+      return ()
+    test.execute()
+
+
+// Parse commandline arguments
+pub fun parse-opts(args = get-args()): io testopts
+  fun set-list(opts: testopts, do-list)
+    val action = if do-list then List else Run
+    opts(action = action)
+
+  val flags = [
+    Flag("l", ["list"], Bool(set-list), "list test names" )
+  ]
+  val (opts, remainder, errs) = parse(Testopts(), flags, get-args())
+  if not(errs.is-nil) then
+    println(errs.join("\n") ++ "\n" ++ flags.usage)
+    throw("Invalid options")
+  opts(includes = filter-from(remainder))
+
+// Main entrypoint for running tests. Parses CLI arguments and runs the relevant tests
+// TODO: extend this to discover tests across multiple files
+pub fun run-tests(f: () -> <test,io> (), reporter: test-reporter<io> = color-reporter): io ()
+  val opts = parse-opts()
+  val tests = collect-tests(f)
+
+  match opts.action()
+    Run ->
+      with reporter
+      execute-tests(opts, tests)
+    List ->
+      tests.foreach fn(t)
+        println(t.identity.full-name)
+
+// Some simple examples
+fun main(): io ()
+  // custom reporter
+  run-tests(reporter = plain-reporter)
+    test("OK")
+      ()
+  println("----")
+
+  // default color-reporter
+  with run-tests()
+  group("Basics")
+    with group("A subgroup")
+    test("Returns continue tests")
+      val res = expect-result(1)
+                  2
+      hint("Continued!")
+      expect(2)
+        1 + res
+      expect(2)
+        1
+  group("Other")
+    test("Wrong expect")
+      expect(1)
+        2
+    test("Additional info")
+      expect(1, details="Really expected 1!")
+        throw("Some error somewhere")

--- a/std/test/run.kk
+++ b/std/test/run.kk
@@ -7,6 +7,7 @@
 ----------------------------------------------------------------------------*/
 module std/test/run
 import std/test/test
+import std/test/report
 import std/os/env
 import std/os/flags
 
@@ -62,6 +63,7 @@ fun execute-tests(opts: testopts, tests: list<test-case<io>>): <test-report,io> 
       summary := summary.execute(test)
     else
       report-skipped(tid)
+      summary := summary(skipped = summary.skipped + 1)
   report-summary(summary)
   if summary.any-failures then
     exit(1)

--- a/std/test/test.kk
+++ b/std/test/test.kk
@@ -5,53 +5,9 @@
    use this file except in compliance with the License. A copy of the License
    can be found in the LICENSE file at the root of this distribution.
 ----------------------------------------------------------------------------*/
-module test/test
+module std/test/test
 
-// The toplevel `test` effect for defining test groups and cases
-pub effect test
-  val current-scope: maybe<scope>
-  fun register-test(test-identity: test-identity, body: () -> <expect,io> ()): ()
-
-// The effect available within a test, for making expectations / assertions
-pub effect expect
-  ctl test-expect(v: expect-value<a>): a
-  fun test-hint(hint: string): ()
-
-value struct location
-  mod: string
-  line: string
-  
-fun location/show(l: location): string
-  l.mod ++ ":" ++ l.line
-
-struct scope
-  scope-id: int
-  parent: maybe<scope>
-  scope-name: string
-  location: location
-
-fun scope/show(s: scope): div string
-  "Scope("++s.scope-id.show ++", "++s.parent.show ++ ", " ++ s.scope-name++")"
-
-// A test, possibly within group / scopes
-abstract struct test-identity
-  test-id: int
-  scope: maybe<scope>
-  name: string
-  location: location
-  
-pub fun test-identity/show(t: test-identity): div string
-  "Test-identity("++t.test-id.show ++", "++t.scope.show ++ ", " ++ t.name ++ ")"
-
-abstract value struct suite-summary
-  failures: int
-  successes: int
-
-pub fun suite-summary(): suite-summary
-  Suite-summary(0, 0)
-
-pub fun summary/any-failures(summary: suite-summary): bool
-  summary.failures > 0
+pub alias test-reporter<e> = (action: () -> <test-report|e> ()) -> e ()
 
 pub effect test-report
   fun report-skipped<a>(test: test-identity): ()
@@ -61,144 +17,75 @@ pub effect test-report
   fun report-end<a>(test: test-identity, failures: int): ()
   fun report-summary<a>(summary: suite-summary): ()
 
-fun indentation(scope: maybe<scope>): div string
+// The toplevel `test` effect for defining test groups and cases
+pub effect test
+  val current-scope: maybe<test-scope>
+  fun register-test(test-identity: test-identity, body: () -> <expect,io> ()): ()
+
+// The effect available within a test, for making expectations / assertions
+pub effect expect
+  ctl test-expect(v: expect-value<a>): a
+  fun test-hint(hint: string): ()
+
+abstract value struct location
+  mod: string
+  line: string
+  
+pub fun location/show(l: location): string
+  l.mod ++ ":" ++ l.line
+
+pub struct test-scope
+  scope-id: int
+  parent: maybe<test-scope>
+  scope-name: string
+  location: location
+
+fun scope/show(s: test-scope): div string
+  "Scope("++s.scope-id.show ++", "++s.parent.show ++ ", " ++ s.scope-name++")"
+
+// A test, possibly within group / scopes
+pub struct test-identity
+  test-id: int
+  scope: maybe<test-scope>
+  name: string
+  location: location
+  
+pub fun test-identity/show(t: test-identity): div string
+  "Test-identity("++t.test-id.show ++", "++t.scope.show ++ ", " ++ t.name ++ ")"
+
+pub value struct suite-summary
+  failures: int
+  successes: int
+  skipped: int
+
+pub fun suite-summary(): suite-summary
+  Suite-summary(0, 0, 0)
+
+pub fun summary/any-failures(summary: suite-summary): bool
+  summary.failures > 0
+
+pub fun indentation(scope: maybe<test-scope>): div string
   scope.map(fn(s) s.parent.indentation ++ "  ").default("")
 
-fun scope/full-name(scope: scope): div string
+pub fun scope/full-name(scope: test-scope): div string
   scope.parent.map(fn(p) p.full-name ++ " ").default("") ++ scope.scope-name
 
 pub fun test/full-name(test: test-identity): div string
   test.scope.map(fn(s) s.full-name ++ " ").default("") ++ test.name
 
-fun report-scope-once(reported-scopes: ref<global, list<int>>, scope: maybe<scope>, report: (scope) -> <st<global>,div|e> ()): <st<global>,div|e> ()
-  match scope
-    Nothing -> ()
-    Just(scope) ->
-      report-scope-once(reported-scopes, scope.parent, report)
-      val reported = !reported-scopes
-      if reported.find(fn(id) -> id == scope.scope-id).is-nothing then
-        reported-scopes := Cons(scope.scope-id, reported)
-        report(scope)
-
-pub fun plain-reporter(action: () -> <test-report,io|e> ()): <io|e> ()
-  var current-failures := 0
-  val reported-scopes = ref([])
-
-  with handler <test-report>
-    fun report-skipped(test)
-      ()
-
-    fun report-start(test)
-      current-failures := 0
-      val infomsg = test.scope.indentation ++ test.name
-      report-scope-once(reported-scopes, test.scope) fn(scope)
-        println(scope.parent.indentation ++ scope.scope-name ++ ":")
-      println(infomsg ++ "(" ++ test.location.show ++ ")...")
-
-    fun report-hint(test, hint)
-      println(test.scope.indentation ++ hint)
-
-    fun report-end(test, failures: int)
-      val infomsg = test.scope.indentation ++ test.name ++ "(" ++ test.location.show ++ "):"
-      val result = if failures == 0 then "OK" else "FAIL"
-      println(infomsg ++ " " ++ result)
-
-    fun report-failure(test: test-identity, failed-expectation)
-      current-failures := current-failures + 1
-      val b = failed-expectation.expectation
-      val location = failed-expectation.location
-      val showa = failed-expectation.show
-      val err = failed-expectation.details
-      match failed-expectation.run-value
-        Error(e) ->
-          println(test.scope.indentation() ++ "  Expect(" ++ location ++ ") == " ++ b.show(?show=showa) ++ ": threw an exception: " ++ e.exn/show ++ err.map(fn(e1) "\n    Details: " ++ e1).default(""))
-        Ok(a) ->
-          println(test.scope.indentation() ++ "  Expect(" ++ location ++ ") == " ++ b.show(?show=showa) ++ ": but got: " ++ a.showa ++ err.map(fn(e) "\n    Details: " ++ e).default(""))
-
-    fun report-summary(summary: suite-summary)
-      println(summary.failures.show ++ " failures, " ++ summary.successes.show ++ " successes")
-
-  mask<local>(action)
-
-pub alias test-reporter<e> = (action: () -> <test-report|e> ()) -> e ()
-
-pub fun color-reporter(action: () -> <test-report,io|e> ()): <io|e> ()
-  var total-successes := 0
-  var total-skipped := 0
-  val reported-scopes = ref([])
-  val green = "\u001b[0;32m"
-  val cyan = "\u001b[0;36m"
-  val red = "\u001b[0;31m"
-  val yellow = "\u001b[0;33m"
-  val reset = "\u001b[0m"
-  var failed-test-names := []
-  var hint-buffer-rev := []
-
-  with handler <test-report>
-    fun report-skipped(test)
-      total-skipped := total-skipped + 1
-
-    fun report-start(test)
-      hint-buffer-rev := []
-      report-scope-once(reported-scopes, test.scope) fn(scope)
-        println(scope.parent.indentation ++ cyan ++ scope.scope-name ++ ":" ++ reset)
-      println(cyan ++ test.scope.indentation ++ test.name ++ "(" ++ test.location.show ++ ")..." ++ reset)
-
-    fun report-hint(test, hint)
-      // accumulate and only output on failure
-      hint-buffer-rev := Cons(hint, hint-buffer-rev)
-
-    fun report-end(test, failures: int)
-      if failures == 0 then
-        println(test.scope.indentation ++ green ++ "- ok" ++ reset)
-      else
-        hint-buffer-rev.reverse.foreach fn(hint)
-          println(test.scope.indentation ++ yellow ++ hint ++ reset)
-
-        println(test.scope.indentation ++ red ++ "- failed\n" ++ reset)
-        failed-test-names := Cons(test.full-name, failed-test-names)
-
-    fun report-failure(test: test-identity, failed-expectation)
-      val b = failed-expectation.expectation
-      val location = failed-expectation.location
-      val showa = failed-expectation.show
-      val err = failed-expectation.details
-      match failed-expectation.run-value
-        Error(e) ->
-          println(red ++ test.scope.indentation() ++ "Expect(" ++ location ++ ") == " ++ b.show(?show=showa) ++ ": threw an exception: " ++ e.exn/show ++ err.map(fn(e1) "\n    Details: " ++ e1).default("") ++ reset)
-        Ok(a) ->
-          println(red ++ test.scope.indentation() ++ "Expect(" ++ location ++ ") == " ++ b.show(?show=showa) ++ ": but got: " ++ a.showa ++ err.map(fn(e) "\n    Details: " ++ e).default("") ++ reset)
-
-    fun report-summary(summary: suite-summary)
-      val color = if summary.failures > 0 then red else green
-      println(
-        color ++
-        summary.failures.show ++ " failures, " ++ summary.successes.show ++ " successes"
-        ++ (if total-skipped > 0 then " (" ++ total-skipped.show ++ " skipped)" else "")
-        ++ reset
-        )
-
-      if summary.failures > 0 then
-        println(red ++ "\nFailed tests:")
-        failed-test-names.foreach fn(name)
-          println(" - " ++ name)
-        println(reset)
-
-  mask<local>(action)
-
-value type expectation<a>
+pub value type expectation<a>
   ExpectedValue(a: a)
   ExpectedError(str: string)
   ExpectedAssertion(str: string)
 
-fun show(a: expectation<a>, ?show: a -> div string): div string
+pub fun show(a: expectation<a>, ?show: a -> div string): div string
   match a
     ExpectedValue(a) -> a.show
     ExpectedError(a) -> "error: " ++ a
     ExpectedAssertion(a) -> "assertion: " ++ a
 
 // An expected value for a test
-struct expect-value<a>
+abstract struct expect-value<a>
   run-value: error<a> // The value of the computation when run
   expectation: expectation<a> // The expected value
   details: maybe<string> // An additional error message providing context of the expectation
@@ -206,6 +93,18 @@ struct expect-value<a>
   location: string // The line where the expectation was made
   eq: (a,a) -> div bool // The equality function for the value
   show: (a) -> div string; // The show function for the value
+
+pub fun show-failed(failed: expect-value<a>): div string
+  val b = failed.expectation
+  val location = failed.location
+  val showa = failed.show
+  val err = failed.details
+  val actual = match failed.run-value
+    Error(e) ->
+      "threw an exception: " ++ e.exn/show
+    Ok(a) ->
+      "but got: " ++ a.showa
+  "Expect(" ++ location ++ ") == " ++ b.show(?show=showa) ++ ": " ++ actual ++ err.map(fn(e) "\nDetails: " ++ e).default("")
 
 // Expects a computation to return a value
 //
@@ -259,7 +158,7 @@ fun gen-id(): st<global> int
 
 // group of tests, requires (and overrides) test-scope
 pub fun group(name: string, f: () -> <test,io|e> (), ?kk-module: string, ?kk-line: string): <test,io|e> ()
-  val scope = Scope(
+  val scope = Test-scope(
     scope-id = gen-id(),
     parent = current-scope,
     scope-name = name,

--- a/std/test/test.kk
+++ b/std/test/test.kk
@@ -44,9 +44,15 @@ abstract struct test-identity
 pub fun test-identity/show(t: test-identity): div string
   "Test-identity("++t.test-id.show ++", "++t.scope.show ++ ", " ++ t.name ++ ")"
 
-value struct suite-summary
+abstract value struct suite-summary
   failures: int
   successes: int
+
+pub fun suite-summary(): suite-summary
+  Suite-summary(0, 0)
+
+pub fun summary/any-failures(summary: suite-summary): bool
+  summary.failures > 0
 
 pub effect test-report
   fun report-skipped<a>(test: test-identity): ()
@@ -54,6 +60,7 @@ pub effect test-report
   fun report-hint<a>(test: test-identity, hint: string): ()
   fun report-failure<a>(test: test-identity, expectation: expect-value<a>): ()
   fun report-end<a>(test: test-identity, failures: int): ()
+  fun report-summary<a>(summary: suite-summary): ()
 
 fun indentation(scope: maybe<scope>): total string
   scope.map(fn(s) s.scope-indent).default("")
@@ -75,8 +82,6 @@ fun report-scope-once(reported-scopes: ref<global, list<int>>, scope: maybe<scop
         report(scope)
 
 pub fun plain-reporter(action: () -> <test-report,io|e> ()): <io|e> ()
-  var total-failures := 0
-  var total-successes := 0
   var current-failures := 0
   val reported-scopes = ref([])
 
@@ -95,10 +100,6 @@ pub fun plain-reporter(action: () -> <test-report,io|e> ()): <io|e> ()
       println(test.scope.indentation ++ hint)
 
     fun report-end(test, failures: int)
-      if current-failures == 0 then
-        total-successes := total-successes + 1
-      else
-        total-failures := total-failures + current-failures
       val infomsg = test.scope.indentation ++ test.name ++ "(" ++ test.location.show ++ "):"
       val result = if failures == 0 then "OK" else "FAIL"
       println(infomsg ++ " " ++ result)
@@ -115,16 +116,14 @@ pub fun plain-reporter(action: () -> <test-report,io|e> ()): <io|e> ()
         Ok(a) ->
           println(test.scope.indentation() ++ "  Expect(" ++ location ++ ") == " ++ b.show(?show=showa) ++ ": but got: " ++ a.showa ++ err.map(fn(e) "\n    Details: " ++ e).default(""))
 
+    fun report-summary(summary: suite-summary)
+      println(summary.failures.show ++ " failures, " ++ summary.successes.show ++ " successes")
+
   mask<local>(action)
-  println(total-failures.show ++ " failures, " ++ total-successes.show ++ " successes")
-  if total-failures > 0 then
-    throw("Tests failed") // TODO exit(1) without raising?
-  ()
 
 pub alias test-reporter<e> = (action: () -> <test-report|e> ()) -> e ()
 
 pub fun color-reporter(action: () -> <test-report,io|e> ()): <io|e> ()
-  var total-failures := 0
   var total-successes := 0
   var total-skipped := 0
   val reported-scopes = ref([])
@@ -152,10 +151,6 @@ pub fun color-reporter(action: () -> <test-report,io|e> ()): <io|e> ()
 
     fun report-end(test, failures: int)
       if failures == 0 then
-        total-successes := total-successes + 1
-      else
-        total-failures := total-failures + failures
-      if failures == 0 then
         println(test.scope.indentation ++ green ++ "- ok" ++ reset)
       else
         hint-buffer-rev.reverse.foreach fn(hint)
@@ -175,22 +170,22 @@ pub fun color-reporter(action: () -> <test-report,io|e> ()): <io|e> ()
         Ok(a) ->
           println(red ++ test.scope.indentation() ++ "Expect(" ++ location ++ ") == " ++ b.show(?show=showa) ++ ": but got: " ++ a.showa ++ err.map(fn(e) "\n    Details: " ++ e).default("") ++ reset)
 
-  mask<local>(action)
-  val color = if total-failures > 0 then red else green
-  println(
-    color ++
-    total-failures.show ++ " failures, " ++ total-successes.show ++ " successes"
-    ++ (if total-skipped > 0 then " (" ++ total-skipped.show ++ " skipped)" else "")
-    ++ reset
-    )
+    fun report-summary(summary: suite-summary)
+      val color = if summary.failures > 0 then red else green
+      println(
+        color ++
+        summary.failures.show ++ " failures, " ++ summary.successes.show ++ " successes"
+        ++ (if total-skipped > 0 then " (" ++ total-skipped.show ++ " skipped)" else "")
+        ++ reset
+        )
 
-  if total-failures > 0 then
-    println(red ++ "\nFailed tests:")
-    failed-test-names.foreach fn(name)
-      println(" - " ++ name)
-    println(reset)
-    throw("Tests failed")
-  ()
+      if summary.failures > 0 then
+        println(red ++ "\nFailed tests:")
+        failed-test-names.foreach fn(name)
+          println(" - " ++ name)
+        println(reset)
+
+  mask<local>(action)
 
 value type expectation<a>
   ExpectedValue(a: a)
@@ -301,11 +296,18 @@ pub fun collect-tests(f: () -> <test,io> ()): io list<test-case<io>>
   }
   tests-rev.reverse
 
-pub fun test/execute(test: test-case<io>): <test-report,io> ()
+// Executes a single test. Returns an updated suite summary
+pub fun execute(summary: suite-summary, test: test-case<io>): <test-report,io> suite-summary
   val tid = test.identity
   report-start(tid)
-  var failures := 0
-  with finally { report-end(tid, failures) }
+  var fail-count := 0
+  fun result()
+    if fail-count == 0 then
+      summary(successes = summary.successes + 1)
+    else
+      summary(failures = summary.failures + fail-count)
+
+  with finally { report-end(tid, fail-count) }
   with handler<expect> {
     fun test-hint(v)
       report-hint(tid, v)
@@ -315,13 +317,13 @@ pub fun test/execute(test: test-case<io>): <test-report,io> ()
       val b = v.expectation
       match a
         Error(_) ->
-          failures := failures + 1
+          fail-count := fail-count + 1
           report-failure(tid, v)
           if v.continue-on-error then
             match b
               ExpectedValue(b') -> resume(b')
-              _ -> ()
-          else ()
+              _ -> result()
+          else result()
         Ok(a') ->
           val good = match b
             ExpectedValue(b') -> (v.eq)(a', b')
@@ -330,13 +332,14 @@ pub fun test/execute(test: test-case<io>): <test-report,io> ()
           if good then
             resume(a')
           else
-            failures := failures + 1
+            fail-count := fail-count + 1
             report-failure(tid, v)
             if v.continue-on-error then
               match b
                 ExpectedValue(b') -> resume(b')
-                _ -> ()
-            else ()
+                _ -> result()
+            else result()
   }
   with mask<test-report>
   (test.body)()
+  result()

--- a/std/test/test.kk
+++ b/std/test/test.kk
@@ -6,21 +6,198 @@
    can be found in the LICENSE file at the root of this distribution.
 ----------------------------------------------------------------------------*/
 module test/test
-// The test effect
+
+// The toplevel `test` effect for defining test groups and cases
 pub effect test
+  val current-scope: maybe<scope>
+  fun register-test(test-identity: test-identity, body: () -> <expect,io> ()): ()
+
+// The effect available within a test, for making expectations / assertions
+pub effect expect
   ctl test-expect(v: expect-value<a>): a
+  fun test-hint(hint: string): ()
 
-pub effect test-scope
-  val scope-name: string
-  val indentation: string
-  fun report-fail(): ()
+value struct location
+  mod: string
+  line: string
+  
+fun location/show(l: location): string
+  l.mod ++ ":" ++ l.line
 
-type expectation<a>
+struct scope
+  scope-id: int
+  parent: maybe<scope>
+  scope-name: string
+  scope-indent: string
+  location: location
+
+fun scope/show(s: scope): div string
+  "Scope("++s.scope-id.show ++", "++s.parent.show ++ ", " ++ s.scope-name++")"
+
+// A test, possibly within group / scopes
+abstract struct test-identity
+  test-id: int
+  scope: maybe<scope>
+  name: string
+  location: location
+  
+pub fun test-identity/show(t: test-identity): div string
+  "Test-identity("++t.test-id.show ++", "++t.scope.show ++ ", " ++ t.name ++ ")"
+
+value struct suite-summary
+  failures: int
+  successes: int
+
+pub effect test-report
+  fun report-skipped<a>(test: test-identity): ()
+  fun report-start<a>(test: test-identity): ()
+  fun report-hint<a>(test: test-identity, hint: string): ()
+  fun report-failure<a>(test: test-identity, expectation: expect-value<a>): ()
+  fun report-end<a>(test: test-identity, failures: int): ()
+
+fun indentation(scope: maybe<scope>): total string
+  scope.map(fn(s) s.scope-indent).default("")
+
+fun scope/full-name(scope: scope): div string
+  scope.parent.map(fn(p) p.full-name ++ " ").default("") ++ scope.scope-name
+
+pub fun test/full-name(test: test-identity): div string
+  test.scope.map(fn(s) s.full-name ++ " ").default("") ++ test.name
+
+fun report-scope-once(reported-scopes: ref<global, list<int>>, scope: maybe<scope>, report: (scope) -> <st<global>,div|e> ()): <st<global>,div|e> ()
+  match scope
+    Nothing -> ()
+    Just(scope) ->
+      report-scope-once(reported-scopes, scope.parent, report)
+      val reported = !reported-scopes
+      if reported.find(fn(id) -> id == scope.scope-id).is-nothing then
+        reported-scopes := Cons(scope.scope-id, reported)
+        report(scope)
+
+pub fun plain-reporter(action: () -> <test-report,io|e> ()): <io|e> ()
+  var total-failures := 0
+  var total-successes := 0
+  var current-failures := 0
+  val reported-scopes = ref([])
+
+  with handler <test-report>
+    fun report-skipped(test)
+      ()
+
+    fun report-start(test)
+      current-failures := 0
+      val infomsg = test.scope.indentation ++ test.name
+      report-scope-once(reported-scopes, test.scope) fn(scope)
+        println(scope.parent.indentation ++ scope.scope-name ++ ":")
+      println(infomsg ++ "(" ++ test.location.show ++ ")...")
+
+    fun report-hint(test, hint)
+      println(test.scope.indentation ++ hint)
+
+    fun report-end(test, failures: int)
+      if current-failures == 0 then
+        total-successes := total-successes + 1
+      else
+        total-failures := total-failures + current-failures
+      val infomsg = test.scope.indentation ++ test.name ++ "(" ++ test.location.show ++ "):"
+      val result = if failures == 0 then "OK" else "FAIL"
+      println(infomsg ++ " " ++ result)
+
+    fun report-failure(test: test-identity, failed-expectation)
+      current-failures := current-failures + 1
+      val b = failed-expectation.expectation
+      val location = failed-expectation.location
+      val showa = failed-expectation.show
+      val err = failed-expectation.details
+      match failed-expectation.run-value
+        Error(e) ->
+          println(test.scope.indentation() ++ "  Expect(" ++ location ++ ") == " ++ b.show(?show=showa) ++ ": threw an exception: " ++ e.exn/show ++ err.map(fn(e1) "\n    Details: " ++ e1).default(""))
+        Ok(a) ->
+          println(test.scope.indentation() ++ "  Expect(" ++ location ++ ") == " ++ b.show(?show=showa) ++ ": but got: " ++ a.showa ++ err.map(fn(e) "\n    Details: " ++ e).default(""))
+
+  mask<local>(action)
+  println(total-failures.show ++ " failures, " ++ total-successes.show ++ " successes")
+  if total-failures > 0 then
+    throw("Tests failed") // TODO exit(1) without raising?
+  ()
+
+pub alias test-reporter<e> = (action: () -> <test-report|e> ()) -> e ()
+
+pub fun color-reporter(action: () -> <test-report,io|e> ()): <io|e> ()
+  var total-failures := 0
+  var total-successes := 0
+  var total-skipped := 0
+  val reported-scopes = ref([])
+  val green = "\u001b[0;32m"
+  val cyan = "\u001b[0;36m"
+  val red = "\u001b[0;31m"
+  val yellow = "\u001b[0;33m"
+  val reset = "\u001b[0m"
+  var failed-test-names := []
+  var hint-buffer-rev := []
+
+  with handler <test-report>
+    fun report-skipped(test)
+      total-skipped := total-skipped + 1
+
+    fun report-start(test)
+      hint-buffer-rev := []
+      report-scope-once(reported-scopes, test.scope) fn(scope)
+        println(scope.parent.indentation ++ cyan ++ scope.scope-name ++ ":" ++ reset)
+      println(cyan ++ test.scope.indentation ++ test.name ++ "(" ++ test.location.show ++ ")..." ++ reset)
+
+    fun report-hint(test, hint)
+      // accumulate and only output on failure
+      hint-buffer-rev := Cons(hint, hint-buffer-rev)
+
+    fun report-end(test, failures: int)
+      if failures == 0 then
+        total-successes := total-successes + 1
+      else
+        total-failures := total-failures + failures
+      if failures == 0 then
+        println(test.scope.indentation ++ green ++ "- ok" ++ reset)
+      else
+        hint-buffer-rev.reverse.foreach fn(hint)
+          println(test.scope.indentation ++ yellow ++ hint ++ reset)
+
+        println(test.scope.indentation ++ red ++ "- failed\n" ++ reset)
+        failed-test-names := Cons(test.full-name, failed-test-names)
+
+    fun report-failure(test: test-identity, failed-expectation)
+      val b = failed-expectation.expectation
+      val location = failed-expectation.location
+      val showa = failed-expectation.show
+      val err = failed-expectation.details
+      match failed-expectation.run-value
+        Error(e) ->
+          println(red ++ test.scope.indentation() ++ "Expect(" ++ location ++ ") == " ++ b.show(?show=showa) ++ ": threw an exception: " ++ e.exn/show ++ err.map(fn(e1) "\n    Details: " ++ e1).default("") ++ reset)
+        Ok(a) ->
+          println(red ++ test.scope.indentation() ++ "Expect(" ++ location ++ ") == " ++ b.show(?show=showa) ++ ": but got: " ++ a.showa ++ err.map(fn(e) "\n    Details: " ++ e).default("") ++ reset)
+
+  mask<local>(action)
+  val color = if total-failures > 0 then red else green
+  println(
+    color ++
+    total-failures.show ++ " failures, " ++ total-successes.show ++ " successes"
+    ++ (if total-skipped > 0 then " (" ++ total-skipped.show ++ " skipped)" else "")
+    ++ reset
+    )
+
+  if total-failures > 0 then
+    println(red ++ "\nFailed tests:")
+    failed-test-names.foreach fn(name)
+      println(" - " ++ name)
+    println(reset)
+    throw("Tests failed")
+  ()
+
+value type expectation<a>
   ExpectedValue(a: a)
   ExpectedError(str: string)
   ExpectedAssertion(str: string)
 
-fun show(a: expectation<a>, ?show: a -> pure string): pure string
+fun show(a: expectation<a>, ?show: a -> div string): div string
   match a
     ExpectedValue(a) -> a.show
     ExpectedError(a) -> "error: " ++ a
@@ -33,13 +210,13 @@ struct expect-value<a>
   details: maybe<string> // An additional error message providing context of the expectation
   continue-on-error: bool // Whether to continue with the expected value (test recovery!)
   location: string // The line where the expectation was made
-  eq: (a,a) -> pure bool // The equality function for the value
-  show: (a) -> pure string; // The show function for the value
+  eq: (a,a) -> div bool // The equality function for the value
+  show: (a) -> div string; // The show function for the value
 
 // Expects a computation to return a value
 //
 // The expected type must have an `(==)` function as well as a `show` function defined for it
-pub fun expect-result(expected: a, run: () -> <exn,test|e> a, details: string = "", continue-on-error=True, ?(==): (a,a) -> pure bool, ?show: (a) -> pure string, ?kk-line: string, ?kk-module: string): <test|e> a
+pub fun expect-result(expected: a, run: () -> <exn,expect|e> a, details: string = "", continue-on-error=True, ?(==): (a,a) -> div bool, ?show: (a) -> div string, ?kk-line: string, ?kk-module: string): <expect|e> a
   val res = try({run()})
   test-expect(Expect-value(
     res, 
@@ -53,11 +230,11 @@ pub fun assert-error(assertion: string, ?kk-line: string, ?kk-module: string)
   test-expect(Expect-value(Ok(False), ExpectedValue(True), Just("Assertion failed: " ++ assertion), False, ?kk-module ++ ":" ++ ?kk-line, (==), show))
   ()
 
-pub fun expect-that(assertion: string, predicate: (a) -> <exn|e> bool, run: () -> <exn,test|e> a, details: string = "", ?(==): (a,a) -> pure bool, ?show: (a) -> pure string, ?kk-line: string, ?kk-module: string): <test|e> a
+pub fun expect-that(assertion: string, predicate: (a) -> <exn|e> bool, run: () -> <exn,expect|e> a, details: string = "", ?(==): (a,a) -> div bool, ?show: (a) -> div string, ?kk-line: string, ?kk-module: string): <expect|e> a
   val res = try({run()})
   match res
     Ok(res) -> 
-      val good = try({mask<test>{predicate(res)}})
+      val good = try({mask<expect>{predicate(res)}})
       test-expect(Expect-value(
         Ok(res), 
         ExpectedAssertion(assertion), 
@@ -75,98 +252,91 @@ pub fun expect-that(assertion: string, predicate: (a) -> <exn|e> bool, run: () -
         (==), show))
 
 // Same as expect-result but does not return the result of the computation, and defaults to not continue on error
-pub fun expect(expected: a, run: () -> <exn,test|e> a, details: string = "", continue-on-error=False, ?(==): (a,a) -> pure bool, ?show: (a) -> pure string, ?kk-line: string, ?kk-module: string): <test|e> ()
+pub fun expect(expected: a, run: () -> <exn,expect|e> a, details: string = "", continue-on-error=False, ?(==): (a,a) -> div bool, ?show: (a) -> div string, ?kk-line: string, ?kk-module: string): <expect|e> ()
   expect-result(expected, run, details, continue-on-error)
   ()
 
-// A top level group of tests
-pub fun group(name: string, f: () -> <test-scope,console|e> (), is-test: bool = False, ?kk-module: string, ?kk-line: string): <console|e> ()
-  val sname = if is-test then "test" else "group"
-  val infomsg = sname ++ "("  ++ name ++ " : " ++ ?kk-module ++ ":" ++ ?kk-line ++ "):"
-  println(infomsg ++ "... ")
-  var anyfail := False
-  with handler
-    val indentation = "  "
-    val scope-name = name
-    fun report-fail() 
-      anyfail := True
-    return(x)
-      if !anyfail then println(infomsg ++ " passed!")
-      else println(infomsg ++ " failed!")
-  mask<local>{f()}
+val next-id-ref: delayed<st<global>, ref<global,int>> = delay { ref(0) }
+fun gen-id(): st<global> int
+  next-id-ref.force.modify fn(r)
+    val id = r
+    r := r + 1
+    id
 
-// A scoped grouping of tests with some name (could be a single test, or a subgroup of tests) 
-fun istest/scope(name: string, is-test: bool, f: () -> <test-scope,console|e> (), ?kk-module: string, ?kk-line: string): <test-scope,console|e> ()
-  val sname = if is-test then "test" else "group"
-  val infomsg = indentation ++ sname ++ "(" ++ name ++ " : " ++ ?kk-module ++ ":" ++ ?kk-line ++ "):" 
-  println(infomsg ++ "... ")
-  var anyfail := False
-  with override
-    val indentation = indentation ++ "  "
-    val scope-name = name
-    fun report-fail() 
-      anyfail := True
-      report-fail()
-    return(x)
-      if !anyfail then println(infomsg ++ " passed!")
-      else println(infomsg ++ " failed!")
+// group of tests, requires (and overrides) test-scope
+pub fun group(name: string, f: () -> <test,io|e> (), ?kk-module: string, ?kk-line: string): <test,io|e> ()
+  val scope = Scope(
+    scope-id = gen-id(),
+    parent = current-scope,
+    scope-name = name,
+    scope-indent = current-scope.indentation() ++ "  ",
+    location = Location(?kk-module, ?kk-line)
+  )
+  with override<test>
+    val current-scope = Just(scope)
+    fun register-test(test-identity, body)
+      register-test(test-identity, body)
   f()
 
-// A subgroup of tests
-pub fun subgroup(name: string, f: () -> <test-scope,console|e> (), is-test: bool = False, ?kk-module: string, ?kk-line: string): <test-scope,console|e> ()
-  scope(name, is-test, f)
+pub fun hint(value: string): expect ()
+  test-hint(value)
 
-// A test 
-pub fun test(name: string, f: () -> <test,test-scope,console,pure|e> (), ?kk-module: string, ?kk-line: string): <console,test-scope,pure|e> ()
-  subgroup(name, {test_(f)}, is-test=True)
+pub fun test(name: string, f: () -> <expect,io> (), ?kk-module: string, ?kk-line: string): <test,io> ()
+  register-test(Test-identity(gen-id(), current-scope, name, Location(?kk-module, ?kk-line)), f)
 
-// Runs a test function and prints the first failure including details or "Passed" if all expectations pass in the test
-fun test_(f: () -> <test,test-scope,console,pure|e> (), ?kk-module: string, ?kk-line: string): <console,test-scope,pure|e> ()
-  with handler
+pub value struct test-case<e>
+  identity: test-identity
+  body: () -> <expect|e> ()
+
+// run at the top level to execute tests, requires a reporter
+// TODO lazy stream instead of an eager list
+pub fun collect-tests(f: () -> <test,io> ()): io list<test-case<io>>
+  var tests-rev := []
+  handle<test>(f) {
+    val current-scope = Nothing
+
+    fun register-test(test, body) {
+      tests-rev := Cons(Test-case(test, body), tests-rev)
+    }
+  }
+  tests-rev.reverse
+
+pub fun test/execute(test: test-case<io>): <test-report,io> ()
+  val tid = test.identity
+  report-start(tid)
+  var failures := 0
+  with finally { report-end(tid, failures) }
+  with handler<expect> {
+    fun test-hint(v)
+      report-hint(tid, v)
+
     ctl test-expect(v)
-      val Expect-value(a, b, err, cont, location, eq, showa) = v
+      val a = v.run-value
+      val b = v.expectation
       match a
-        Error(e) ->
-          println(indentation ++ "  Expect(" ++ location ++ ") == " ++ b.show(?show=showa) ++ ": threw an exception: " ++ e.exn/show ++ err.map(fn(e1) "\n    Details: " ++ e1).default(""))
-          report-fail()
-          if cont then 
+        Error(_) ->
+          failures := failures + 1
+          report-failure(tid, v)
+          if v.continue-on-error then
             match b
-              ExpectedValue(b') -> resume(b') 
+              ExpectedValue(b') -> resume(b')
               _ -> ()
           else ()
         Ok(a') ->
           val good = match b
-            ExpectedValue(b') -> a'.eq(b')
+            ExpectedValue(b') -> (v.eq)(a', b')
             ExpectedError(_) -> False
-            ExpectedAssertion(_) -> True 
-          if good then 
+            ExpectedAssertion(_) -> True
+          if good then
             resume(a')
           else
-            report-fail()
-            println(indentation ++ "  Expect(" ++ location ++ ") == " ++ b.show(?show=showa) ++ ": but got: " ++ a'.showa ++ err.map(fn(e) "\n    Details: " ++ e).default(""))
-            if cont then 
+            failures := failures + 1
+            report-failure(tid, v)
+            if v.continue-on-error then
               match b
-                ExpectedValue(b') -> resume(b') 
+                ExpectedValue(b') -> resume(b')
                 _ -> ()
             else ()
-  f()
-
-// Some simple examples
-fun test-tests(): <console,pure|e> ()
-  group("Basics")
-    with subgroup("A subgroup")
-    test("Returns continue tests")
-      val res = expect-result(1) 
-                  2
-      println("Continued!")
-      expect(2)
-        1 + res
-      expect(2) 
-        1
-  group("Other")
-    test("Wrong expect")
-      expect(1) 
-        2
-    test("Additional info")
-      expect(1, details="Really expected 1!") 
-        throw("Some error somewhere")
+  }
+  with mask<test-report>
+  (test.body)()

--- a/std/test/test.kk
+++ b/std/test/test.kk
@@ -28,7 +28,6 @@ struct scope
   scope-id: int
   parent: maybe<scope>
   scope-name: string
-  scope-indent: string
   location: location
 
 fun scope/show(s: scope): div string
@@ -62,8 +61,8 @@ pub effect test-report
   fun report-end<a>(test: test-identity, failures: int): ()
   fun report-summary<a>(summary: suite-summary): ()
 
-fun indentation(scope: maybe<scope>): total string
-  scope.map(fn(s) s.scope-indent).default("")
+fun indentation(scope: maybe<scope>): div string
+  scope.map(fn(s) s.parent.indentation ++ "  ").default("")
 
 fun scope/full-name(scope: scope): div string
   scope.parent.map(fn(p) p.full-name ++ " ").default("") ++ scope.scope-name
@@ -264,7 +263,6 @@ pub fun group(name: string, f: () -> <test,io|e> (), ?kk-module: string, ?kk-lin
     scope-id = gen-id(),
     parent = current-scope,
     scope-name = name,
-    scope-indent = current-scope.indentation() ++ "  ",
     location = Location(?kk-module, ?kk-line)
   )
   with override<test>


### PR DESCRIPTION
This is basically a rewrite of the `test` module - I considered splitting it up into smaller PRs but I figured it'd be easier to discuss the whole thing at once than across 5 PRs. Happy to talk over any of these changes and alter things further if necessary.

What I've done and why:

## Split up test/expect

`test` is the effect for defining test cases & groups. `subgroup` didn't seem necessary since `group` can now work inside another `group`.

`expect` is the effect for defining assertions _inside_ a test body. Its implementation is unchanged, just renamed from the existing `test` effect.

This change ensures every assertion is associated with a test case, which seems like a good idea but also helps have a clear interface for reporting errors.

## Add reporter functionality

This extracts the reporting from the execution, so you can use different reporters (e.g. you could add a structured JSON/XML reporter to integrate with tooling). It also adds a few new features to test formatting:

 - summarized results at the end of the run
 - a `hint` function which is like `println`, but it accumulates and is only printed if the test fails

I've left the `plain-reporter` doing mostly what the previous reporter did, but introduced a `color-reporter` (the new default) which uses colours to make the test results more readable.

Here's the example test output using the new color-reporter:

![Screenshot 2025-05-03 at 1 55 13 pm](https://github.com/user-attachments/assets/e2fb82a3-b9ec-41f3-9764-6388e39b51ee)

## Distinct test collection / execution

Instead of running tests inline, we collect all the tests first. This would make it easier to e.g. run tests in parallel (I haven't implemented anything particular around async tests yet though).

## Command-line parsing

My ideal end-state would be to have some kind of builtin test-runner which collects all the tests across every module in a project, and runs them all. That would require some kind of changes from the language, so for now  I've put the functionality in the `run-tests` wrapper function. For now the only flag is `--list` (to list instead of running tests), and any extra arguments are taken as filters to narrow down the set of tests to run.

## Breaking changes:

The main breaking changes that users would notice are:

 - `subgroup` just becomes `group`
 - explicit mentions of the `test` effect might need to be renamed `expect`
 - you can't assert within a group, only within a `test` (I'd be surprised if this is common, but I haven't checked)

Once there's some agreement that this is a good direction, I'll make sure the existing test suite works with the changes.