### PR TITLE
add std/exn/ctx for adding contextual details to errors

### DIFF
--- a/std/core-extras.kk
+++ b/std/core-extras.kk
@@ -8,6 +8,7 @@
 
 module std/core-extras
 import std/core/undiv
+import std/core/exn
 
 extern import 
   c file "inline/core-extras"
@@ -288,3 +289,17 @@ pub inline fip extern ssize_t/(<) : (ssize_t,ssize_t) -> bool
 
 pub extern read-byte-file(path: string): vector<int8>
   c "kk_os_read_byte_file"
+
+// TODO: use core/std/exit after https://github.com/koka-lang/koka/pull/703 is released
+pub extern exit(i: int): io-noexn ()
+  c inline "exit(kk_integer_clamp32(#1, kk_context()))"
+  js inline "throw(`Exited with code: ${#1}`)"
+
+// Compare unit values. Useful to build composite equality for structures containing a unit (e.g. either<string, ()>)
+pub fun unit/(==)(a: (), b: ()): bool { True }
+
+// Show instance for `error<t>`
+pub fun error/show(a: exn/error<t>, ?show: (t) -> e string): e string
+  match (a)
+    Ok(a) -> a.show
+    Error(e) -> e.exn/show

--- a/std/exn/ctx.kk
+++ b/std/exn/ctx.kk
@@ -1,0 +1,91 @@
+// TODO: uncomment after https://github.com/koka-lang/koka/issues/711
+// module std/exn/ctx
+
+import std/core/exn
+import std/core-extras
+
+// A module for extending exceptions with a contextual trace.
+// This is similar to a stack trace, except it contains
+// only explicitly annotated information.
+// This module is inspired by the `anyhow` crate from rust
+type msg
+  Lazy(f: () -> string)
+  Strict(s: string)
+
+fun msg/show(msg: msg)
+  match msg
+    Strict(s) -> s
+    Lazy(f) -> f()
+
+struct error-ctx
+  base: exception
+  chain: list<msg>
+
+extend type exception-info
+  TraceCtx(error: error-ctx)
+
+fun to-ctx(e: exception): error-ctx
+  match e.info
+    TraceCtx(error: error-ctx) -> error
+    _ -> Error-ctx(e, [])
+
+// get the root exception, removing any TraceCtx layers
+pub fun root(e: exception): div exception
+  match e.info
+    TraceCtx(ectx: error-ctx) -> root(ectx.base)
+    _ -> e
+
+fun value/add-trace(e: exception, desc: msg): exception
+  val ectx = e.to-ctx
+  Exception(e.message, TraceCtx(ectx(chain = Cons(desc, ectx.chain))))
+
+// add contextual information if action fails
+pub fun lazy/error-ctx(desc: () -> string, action: () -> <exn|e> a): <exn|e> a
+  with handler<exn>
+    final ctl throw-exn(e) { throw-exn(e.add-trace(Lazy(desc))) }
+  mask behind <exn> { action() }
+
+// add contextual information if action fails
+pub fun string/error-ctx(desc: string, action: () -> <exn|e> a): <exn|e> a
+  with handler<exn>
+    final ctl throw-exn(e) { throw-exn(e.add-trace(Strict(desc))) }
+  mask behind <exn> { action() }
+
+// Get a list of messages, from the outermost
+// context up to the innermost exception message
+pub fun ctx-list(e: exception): list<string>
+  e.to-ctx.chain.map(show) ++ [e.message]
+
+// show exception with full contextual trace
+pub fun show-with-ctx(e: exception): string
+  var result := "Error: "
+  match e.ctx-list
+    [] -> () // impossible
+    Cons(outer, []) ->
+      result := result ++ outer
+
+    Cons(outer, chain) ->
+      result := result ++ outer
+      result := result ++ "\n\nCaused by:"
+      if chain.length == 1 then
+        chain.foreach fn(m)
+          result := result ++ "\n  " ++ m
+      else
+        chain.foreach-indexed fn(i, m)
+          result := result ++ "\n  " ++ (i+1).show ++ ". " ++ m
+  result
+
+// Wrap an exception effect to report it and exit the process on
+// failure. Ideal for use as `with trace-handler` on the first line of
+// a `main` function
+pub fun error-ctx-handler(action: () -> <io|e> ()): <io-noexn|e> ()
+  try(action) fn(e)
+    print("Uncaught exception: ")
+    println(e.show-with-ctx)
+    exit(-1)
+
+// demonstrate trace-handler
+fun main()
+  with error-ctx-handler
+  with error-ctx("outer")
+  throw("inner")

--- a/std/test/run.kk
+++ b/std/test/run.kk
@@ -10,6 +10,7 @@ import std/test/test
 import std/test/report
 import std/os/env
 import std/os/flags
+import std/core-extras
 
 type test-action
   Run
@@ -68,7 +69,7 @@ fun execute-tests(opts: testopts, tests: list<test-case<io>>): <test-report,io> 
       summary := summary(skipped = summary.skipped + 1)
   report-summary(summary)
   if summary.any-failures then
-    exit(1)
+    core-extras/exit(1)
 
 // Parse commandline arguments
 pub fun parse-opts(args = get-args()): io testopts

--- a/std/test/test.kk
+++ b/std/test/test.kk
@@ -12,9 +12,7 @@ import std/num/random
 import std/num/ddouble
 import std/num/float64
 import std/num/int64
-
-// TODO put this somewhere in core
-fun unit/(==)(a: (), b: ()): bool { True }
+import std/core-extras
 
 pub alias test-reporter<e> = (action: () -> <test-report|e> ()) -> e ()
 
@@ -118,8 +116,8 @@ pub fun show-failed(failed: expect-value<a>): div string
     Error(e) ->
       "threw an exception: " ++ e.exn/show
     Ok(a) ->
-      "but got: " ++ a.showa
-  "Expect(" ++ location ++ ") == " ++ b.show(?show=showa) ++ ": " ++ actual ++ err.map(fn(e) "\nDetails: " ++ e).default("")
+      "     got: " ++ a.showa
+  "Expectation failed ("++ location ++ ")\nexpected: " ++ b.show(?show=showa) ++ "\n" ++ actual ++ err.map(fn(e) "\nDetails: " ++ e).default("")
 
 // Expects a computation to return a value
 //

--- a/tests/exn/ctx-tests.kk
+++ b/tests/exn/ctx-tests.kk
@@ -1,0 +1,46 @@
+import std/test
+import std/exn/ctx
+
+fun expect-ex(expected: string, action: () -> exn ()): <exn,expect> ()
+  try({ action(); throw("Test didn't throw an error") }) fn(ex)
+    expect(expected) { show-with-ctx(ex) }
+
+fun raise() { throw("File not found") }
+
+fun main()
+  with run-tests
+  fun multi-context()
+    val config-file = "~/.some-config"
+    with error-ctx("Program failed")
+    with error-ctx { "Initialization error" }
+    with error-ctx { "Error loading " ++ config-file }
+    raise()
+
+  test("ctx-list")
+    expect([
+      "Program failed",
+      "Initialization error",
+      "Error loading ~/.some-config",
+      "File not found"
+    ])
+      try({ multi-context(); [] }, ctx-list)
+
+  group("rendering exception context")
+    test("no-context")
+      expect-ex("Error: File not found", raise)
+
+    test("single-context")
+      expect-ex("Error: Can't load settings\n\nCaused by:\n  File not found")
+        with error-ctx { "Can't load settings" }
+        raise()
+
+    test("multiple context")
+      expect-ex(r#"
+Error: Program failed
+
+Caused by:
+  1. Initialization error
+  2. Error loading ~/.some-config
+  3. File not found
+      "#.trim, multi-context)
+


### PR DESCRIPTION
In rust I use and love [anyhow](https://docs.rs/anyhow/latest/anyhow/) for attaching semantically relevant context to errors. Koka's extensible `exn-info` makes this easy to implement, using both static and lazy strings 🥳 

The main downside is that I would have liked to have my `show(exn)` used over the default one, but if I tried to export is as `show` then that causes ambiguity, which doesn't actually help.