### PR TITLE
add std/test/detect to run multiple test modules

### DIFF
--- a/std/test/detect.kk
+++ b/std/test/detect.kk
@@ -1,0 +1,77 @@
+// CLI to detect and execute tests.
+//
+// Test modules are discoverd from ./test/**/*-test.kk
+// Each module MUST expose a `suite` function with effect `test,io`.
+//   pub fun suite(): test ()
+//
+// This function body should NOT invoke `run-tests`, as that will
+// embed a test suite within an IO, rather than merging tests across modules.
+//
+// Note: this spawns `koka` from your PATH, and does not yet
+// handle special characters in arguments properly.
+module std/test/detect
+
+import std/test
+import std/os/path
+import std/os/env
+import std/os/dir
+import std/data/sort
+import std/core/sslice
+import std/os/path
+import std/os/file
+import std/os/process
+import std/core-extras
+
+fun main()
+  val test-path = generate-test-runner()
+
+  // run the generated tests, passing through any arguments
+  val args = get-args().map fn(arg)
+    // basic escaping effort, TODO a version of run-system that accepts a list of args
+    "'" ++ arg ++ "'"
+  .join(" ")
+  val cmd = "koka -e " ++ test-path.string ++ " -- " ++ args
+
+  println(" + " ++ cmd)
+  val status = run-system(cmd)
+  exit(status)
+
+fun is-test-path(p: path)
+  p.basename.ends-with("-tests.kk").is-just && p.is-file
+
+fun import-path(p: path)
+  p.dirparts.join("/").trim-right(".kk")
+
+// TODO: detect clashes if multiple paths map to the same module-name
+fun module-name(path: string)
+  path.replace-all("/","-").replace-all(".","-")
+
+fun generate-test-runner()
+  var import-lines := []
+  var test-lines := []
+
+  val test-files = path("tests")
+    .list-directory-recursive
+    .filter(is-test-path)
+    .map(import-path)
+    .sort
+
+  test-files.foreach fn(f)
+    import-lines := Cons("import " ++ f.module-name ++ " = " ++ f, import-lines)
+    test-lines := test-lines ++ [
+      "  group(\"" ++ f ++ ".kk\")",
+      "    " ++ f.module-name ++ "/suite()",
+      ""
+    ]
+
+  val lines = import-lines ++ [
+      "import std/test",
+      "fun main()",
+      "  with run-tests"
+    ] ++ test-lines
+
+  // TODO: proper tempname to avoid clashes
+  // TODO: delete this file afterwards
+  val generated-path = tempdir() / "generated-tests.kk"
+  write-text-file(generated-path, lines.join("\n"))
+  return generated-path

--- a/std/test/run.kk
+++ b/std/test/run.kk
@@ -37,6 +37,7 @@ fun filter-from(args: list<string>)
     Include(args)
 
 reference struct testopts
+  help: bool = False
   includes: test-filter = All
   action: test-action = Run
   sample-count: int = 100
@@ -76,6 +77,8 @@ pub fun parse-opts(args = get-args()): io testopts
   fun set-list(opts: testopts, do-list)
     val action = if do-list then List else Run
     opts(action = action)
+
+  fun set-help(opts: testopts, _) { opts(help = True) }
   
   fun set-sample-count(opts: testopts, c: maybe<string>)
     val count = match c
@@ -90,15 +93,19 @@ pub fun parse-opts(args = get-args()): io testopts
       Nothing -> opts
 
   val flags = [
+    Flag("h", ["help"], Bool(set-help), "print usage" ),
     Flag("l", ["list"], Bool(set-list), "list test names" ),
     Flag("", ["samples"], Opt(set-sample-count, "COUNT"), "set default sample count for prop-tests" ),
     Flag("", ["seed"], Opt(set-seed, "INT"), "set RNG seed (for each test; only use to reproduce failures)" ),
   ]
 
   val (opts, remainder, errs) = parse(Testopts(), flags, get-args())
-  if not(errs.is-nil) then
+  if opts.help || not(errs.is-nil) then
     println(errs.join("\n") ++ "\n" ++ flags.usage)
-    throw("Invalid options")
+    if opts.help then
+      core-extras/exit(0)
+    else
+      throw("Invalid options")
   opts(includes = filter-from(remainder))
 
 // Main entrypoint for running tests. Parses CLI arguments and runs the relevant tests.

--- a/std/test/test.kk
+++ b/std/test/test.kk
@@ -284,5 +284,5 @@ pub fun execute(summary: suite-summary, test: test-case<io>, seed: maybe<int>): 
             else result()
   }
   with mask<test-report>
-  expect(()) { (test.body)() }
+  expect((), ?kk-line=tid.location.line, ?kk-module=tid.location.mod) { (test.body)() }
   result()

--- a/tests/exn/ctx-tests.kk
+++ b/tests/exn/ctx-tests.kk
@@ -7,8 +7,9 @@ fun expect-ex(expected: string, action: () -> exn ()): <exn,expect> ()
 
 fun raise() { throw("File not found") }
 
-fun main()
-  with run-tests
+fun main() { run-tests(suite) }
+
+pub fun suite()
   fun multi-context()
     val config-file = "~/.some-config"
     with error-ctx("Program failed")

--- a/tests/random/property-tests.kk
+++ b/tests/random/property-tests.kk
@@ -2,8 +2,9 @@ import std/test
 import std/data/random
 import std/num/random
 
-fun main()
-  with run-tests()
+fun main() { run-tests(suite) }
+
+fun suite()
   prop-test("sample")
     val n = random-int()
     expect((n % 3) >= 0, details = n.show ++ " % 3 = " ++ (n%3).show) { True }


### PR DESCRIPTION
Ultimately I want something much more integrated with the compiler / package manager / tooling, but for now this serves the purpose of "run all the tests", we can improve from here :)

**Note:** I went for the pattern of `test/**/*-test.kk`, which doesn't match our existing structure. I think test singular is more common (e.g it's what go does), and it requires ever so slightly less typing 😆

If we're OK with this I'll rename the existing tests directory (new PR or just do it in this one?).