### PR TITLE
fix(test): remove incorrect effect annotation `<io,test>` in test suites

### DIFF
--- a/test/data/deque-test.kk
+++ b/test/data/deque-test.kk
@@ -10,7 +10,7 @@ fun item/(==)(i: maybe<int>, j: maybe<int>) : bool
     (Just(x), Just(y)) -> x == y
     _ -> False
 
-fun suite(): <io,test> ()
+fun suite()
   group("Deque")
     test("push-front")
       val deq = unit/deque()

--- a/test/data/hashmap-test.kk
+++ b/test/data/hashmap-test.kk
@@ -5,7 +5,7 @@ import std/test
 pub fun main()
   run-tests(suite)
 
-pub fun suite(): <io,test> ()
+pub fun suite()
   fun hash-map()
     arbitrary { random/hash-map(1) }
 

--- a/test/data/hashset-test.kk
+++ b/test/data/hashset-test.kk
@@ -3,7 +3,7 @@ import std/data/hash
 import std/test
 
 
-fun suite(): <io,test> ()
+fun suite()
   group("hash-set")
     test("insert")
       val hs = thread/hash-set(1)

--- a/test/data/heap-test.kk
+++ b/test/data/heap-test.kk
@@ -8,7 +8,7 @@ fun mb/(==)(a: maybe<int>, b: maybe<int>)
     (Just(x), Just(y)) -> x == y
     _ -> False
 
-fun suite(): <io,test> ()
+fun suite()
   group("heap")
     test("heap min ordered")
       expect(Just(1))

--- a/test/data/linearmap-test.kk
+++ b/test/data/linearmap-test.kk
@@ -2,7 +2,7 @@ import std/data/linearmap
 import std/test
 
 
-fun suite(): <io,test> ()
+fun suite()
   group("add")
     test("add already present")
       expect(LinearMap([(1, "a"), (2, "b")]))

--- a/test/data/linearset-test.kk
+++ b/test/data/linearset-test.kk
@@ -2,7 +2,7 @@ import std/data/linearset
 import std/test
 
 
-fun suite(): <io,test> ()
+fun suite()
   group("linearset")
     test("Basics")
       val s = linear-set([1, 2, 3])

--- a/test/data/trie-test.kk
+++ b/test/data/trie-test.kk
@@ -1,7 +1,7 @@
 import std/data/trie
 import std/test
 
-fun suite(): <io,test> ()
+fun suite()
   val t = trie/empty().add("Hello")
   val t1 = t.add("World").add("Worship")
   group("trie")

--- a/test/data/vector-list-test.kk
+++ b/test/data/vector-list-test.kk
@@ -4,7 +4,7 @@ import std/core/unsafe
 
 reference struct something {i: int}
 
-fun suite(): <io,test> ()
+fun suite()
   group("vlist")
     test("push")
       val vec = unit/vector-list() 


### PR DESCRIPTION
Some test functions were incorrectly annotated with `<io,test>`, but the correct type would be `<io,test<io>>`. Removed the annotation to let the compiler infer the correct effect type automatically. Affected 8 files.