### PR TITLE
fix: wrapping comp in direct handle block

### DIFF
--- a/std/fixpoint/fixpoint-memo.kk
+++ b/std/fixpoint/fixpoint-memo.kk
@@ -20,40 +20,38 @@ fun cache(comp: () -> <pure,cache<k,r>|e> d, ?order2: (k, k) -> pure order2<k>,
         // trace("Updating " ++ resumes.length.show ++ " deps for " ++ s.show ++ " with " ++ c.c/show)
         resumes.list/foreach(fn(resumption) {resumption(change); ()})
       Nothing -> ()
-  val do = 
-    with handler
-      fun add-result(key, change)
-        // trace("Adding result for " ++ s.s/show ++ " " ++ c.c/show)
-        match cache.lookup(key)
-          Just(r') ->
-            val (changed, r'') = join(r', change)
-            if changed then 
-              cache := cache.set(key, r'')
-              update(key, change)
-            else ()
-          Nothing -> 
-            cache := cache.set(key, bottom.join(change).snd)
+  handle(comp)
+    fun add-result(key, change)
+      // trace("Adding result for " ++ s.s/show ++ " " ++ c.c/show)
+      match cache.lookup(key)
+        Just(r') ->
+          val (changed, r'') = join(r', change)
+          if changed then 
+            cache := cache.set(key, r'')
             update(key, change)
-      fun is-cached(key)
-        if cache.contains(key) || deps.contains(key) then True
-        else
-          cache := cache.set(key, bottom)
-          deps := deps.set(key, Nil)
-          False
-      ctl depend(key)
-        // trace("Adding dep for " ++ s.s/show)
-        match deps.lookup(key)
-          Just(resumes) ->
-            val ress = Cons(fn(r) resume(r), resumes)
-            deps := deps.set(key, ress)
-        match cache.lookup(key)
-          Just(r) -> r.changes.foreach(fn(change) resume(change))
-      ctl do-each(ss)
-        ss.foreach(fn(s) resume(s))
-      final ctl none()
-        ()
-      return(x) ()
-    comp()
+          else ()
+        Nothing -> 
+          cache := cache.set(key, bottom.join(change).snd)
+          update(key, change)
+    fun is-cached(key)
+      if cache.contains(key) || deps.contains(key) then True
+      else
+        cache := cache.set(key, bottom)
+        deps := deps.set(key, Nil)
+        False
+    ctl depend(key)
+      // trace("Adding dep for " ++ s.s/show)
+      match deps.lookup(key)
+        Just(resumes) ->
+          val ress = Cons(fn(r) resume(r), resumes)
+          deps := deps.set(key, ress)
+      match cache.lookup(key)
+        Just(r) -> r.changes.foreach(fn(change) resume(change))
+    ctl do-each(ss)
+      ss.foreach(fn(s) resume(s))
+    final ctl none()
+      ()
+    return(x) ()
   cache
 
 // Inserts a memoization point at a recursive invocation

--- a/std/fixpoint/memo-partial-order-fine-grained.kk
+++ b/std/fixpoint/memo-partial-order-fine-grained.kk
@@ -33,33 +33,30 @@ fun cache(change-lattice: change-lattice<r,c>, comp: () -> <pure,cache<k,c>,each
                                                 ?k/show: k -> pure string, ?r/show: r -> pure string, ?c/show: c -> pure string): <pure|e> rbmap<k,r>
   val Change-lattice(bottom, join, changes) = change-lattice
   var cache : some<k,r,c,e> rbmap<k,cache-entry<r,c,e>> := empty()
-  val do = 
-    with handler
-      fun add-result(key, change)
-        // trace("Adding result for " ++ k.k/show ++ " " ++ c.c/show)
-        match cache.lookup(key)
-          Just(Cache-entry(current, deps)) ->
-            val (changed, new) = join(current, change)
-            if changed then 
-              cache := cache.set(key, Cache-entry(new, deps))
-              deps.foreach(fn(resumption) resumption(change))
-            else ()
-          Nothing -> 
-            cache := cache.set(key, Cache-entry(join(bottom, change).snd, []))
-      fun is-cached(k)
-        if cache.contains(k) then True
-        else
-          cache := cache.set(k, Cache-entry(bottom, []))
-          False
-      ctl depend(key)
-        // trace("Adding dep for " ++ k.k/show)
-        match cache.lookup(key)
-          Just(Cache-entry(current, deps)) -> 
-            cache := cache.set(key, Cache-entry(current, Cons(fn(change) resume(change), deps)))
-            changes(current).foreach(fn(change) resume(change))
-      return(x) ()
-    with nondet
-    comp()
+  handle({ nondet(comp) })
+    fun add-result(key, change)
+      // trace("Adding result for " ++ k.k/show ++ " " ++ c.c/show)
+      match cache.lookup(key)
+        Just(Cache-entry(current, deps)) ->
+          val (changed, new) = join(current, change)
+          if changed then 
+            cache := cache.set(key, Cache-entry(new, deps))
+            deps.foreach(fn(resumption) resumption(change))
+          else ()
+        Nothing -> 
+          cache := cache.set(key, Cache-entry(join(bottom, change).snd, []))
+    fun is-cached(k)
+      if cache.contains(k) then True
+      else
+        cache := cache.set(k, Cache-entry(bottom, []))
+        False
+    ctl depend(key)
+      // trace("Adding dep for " ++ k.k/show)
+      match cache.lookup(key)
+        Just(Cache-entry(current, deps)) -> 
+          cache := cache.set(key, Cache-entry(current, Cons(fn(change) resume(change), deps)))
+          changes(current).foreach(fn(change) resume(change))
+    return(x) ()
   cache.remove-deps
 
 // Inserts a memoization point at a recursive invocation

--- a/std/fixpoint/memo-partial-order.kk
+++ b/std/fixpoint/memo-partial-order.kk
@@ -36,33 +36,30 @@ fun cache(comp: () -> <pure,cache<k,r>,each|e> b, ?order2: (k, k) -> pure order2
                                                 ?join: (r, r) -> (bool, r), 
                                                 ?s/show: k -> string, ?r/show: r -> string): <pure|e> rbmap<k,r>
   var cache : some<k,r,e> rbmap<k,cache-entry<r,e>> := empty()
-  val do = 
-    with handler
-      fun add-result(key, change)
-        // trace("Adding result for " ++ s.s/show ++ " " ++ r.r/show)
-        match cache.lookup(key)
-          Just(Cache-entry(result, deps)) ->
-            val (changed, new) = join(result, change)
-            if changed then 
-              cache := cache.set(key, Cache-entry(new, deps))
-              deps.foreach(fn(resumption) resumption(change))
-            else ()
-          Nothing -> 
-            cache := cache.set(key, Cache-entry(change, []))
-      fun is-cached(key)
-        if cache.contains(key) then True
-        else
-          cache := cache.set(key, Cache-entry(bottom, []))
-          False
-      ctl depend(key)
-        // trace("Adding dep for " ++ s.s/show)
-        match cache.lookup(key)
-          Just(Cache-entry(current, deps)) -> 
-            cache := cache.set(key, Cache-entry(current, Cons(fn(change) resume(change), deps)))
-            resume(current)
-      return(x) ()
-    with nondet
-    comp()
+  handle({ nondet(comp) })
+    fun add-result(key, change)
+      // trace("Adding result for " ++ s.s/show ++ " " ++ r.r/show)
+      match cache.lookup(key)
+        Just(Cache-entry(result, deps)) ->
+          val (changed, new) = join(result, change)
+          if changed then 
+            cache := cache.set(key, Cache-entry(new, deps))
+            deps.foreach(fn(resumption) resumption(change))
+          else ()
+        Nothing -> 
+          cache := cache.set(key, Cache-entry(change, []))
+    fun is-cached(key)
+      if cache.contains(key) then True
+      else
+        cache := cache.set(key, Cache-entry(bottom, []))
+        False
+    ctl depend(key)
+      // trace("Adding dep for " ++ s.s/show)
+      match cache.lookup(key)
+        Just(Cache-entry(current, deps)) -> 
+          cache := cache.set(key, Cache-entry(current, Cons(fn(change) resume(change), deps)))
+          resume(current)
+    return(x) ()
   cache.remove-deps
 
 // Inserts a memoization point at a recursive invocation


### PR DESCRIPTION
Rewrites `with handler ... comp()` as `handle(comp) ...` to prevent type inference issues with local effects.

When compiling the original form with `with handler ... comp()`, the compiler gives a type inference error:
```koka
effects do not match
context        :     with handler
                 ...
                     comp()
term           :     comp()
inferred effect: <cache<$a,$b>,div,exn|$e>
expected effect: <cache<$a,$b>,div,exn,local<_h>|_e1>
```