### PR TITLE
add `let` module for dynamically bound variables

### DIFF
--- a/std/let.kk
+++ b/std/let.kk
@@ -1,0 +1,124 @@
+/*----------------------------------------------------------------------------
+   Copyright 2026, Koka-Community Authors
+
+   Licensed under the MIT License ("The License"). You may not
+   use this file except in compliance with the License. A copy of the License
+   can be found in the LICENSE file at the root of this distribution.
+----------------------------------------------------------------------------*/
+
+/*
+This module is inspired by rspec's `let` utility. It allows you to define
+lazy variables which can be overridden in a sub scope.
+
+When the value is computed, all dependent variables take their bindings
+from the current scope, rather than the scope where that value was defined.
+That's fairly abstract, a common practical use case is in tests.
+
+It's common for test cases to have a set of data which is shared between
+many test cases, but allowing for individual test cases to override
+individual parts.
+
+If this data is just a few variables, you can get by with a little repetition:
+
+```
+val isbn = "978-1-56619-909-4"
+val title = "The Best Book"
+val author = "Eric Carle"
+
+group("a long title")
+  val title = "I can't believe this title is so long did nobody think of that?"
+  test("it should fit in a single shelf")
+    expect(1)
+      stack-shelves([Book(isbn, author, title)]).length
+```
+
+With `let` you can setup reusable and related data in a way that
+allows individual groups or tests to override precisely the details
+they depend on.
+
+This reduces repetition, leading to more terse and readable
+test bodies. Here's an example:
+
+```
+val isbn = let { "978-1-56619-909-4" }
+val title = let { "The Best Book" }
+val author = let { "Eric Carle" }
+val book = let { Book(isbn.get, author.get, title.get) }
+val books = let { [book.get] }
+fun shelves() stack-shelves(books.get)
+
+group("a long title")
+  with title.set { "I can't believe this title is so long did nobody think of that?" }
+
+  test("it should fit on a single shelf")
+    expect(1) { shelves().length }
+
+group("ten books")
+  with books.set
+    val b = book.get
+    [b, b, b, b, b, b, b, b, b, b]
+      
+  test("requires two shelves")
+    expect(2) { shelves().length }
+```
+
+Note: Unlike in rspec, these variables are not currently memoized -
+they are reevaluated on each call to `get`.
+*/
+
+module std/let
+
+pub effect let
+  fun unsafe-binding(name: letvar<e,a>): (() -> e a)
+  fun unsafe-bindings(): list<(int, any)>
+
+abstract struct letvar<e,a>
+  uid: int
+  default: () -> e a
+
+pub fun empty-scope(f: () -> <let|e> a): e a
+  handle<let>(f)
+    fun unsafe-binding(name) (name.default)
+    fun unsafe-bindings() []
+
+pub fun @default-let(f: () -> <let|e> a): e a
+  empty-scope(f)
+
+pub fun let(default: () -> <let|e> a): ndet letvar<<let|e>,a>
+  Letvar(unique(), default)
+
+pub fun get(query: letvar<<let|e>,a>): <let|e> a
+  unsafe-binding(query)()
+
+pub fun let-undefined(?kk-module: string, ?kk-line: string): ndet letvar<<let,exn|e>,a>
+  let { throw("`let` used without being defined (" ++ ?kk-module ++ ":" ++ ?kk-line ++")") }
+
+// Override a binding - the new definition must have the same effect type.
+// The effect type of the block can be unrelated to the binding's effect
+// (but it will be a superset if you access the binding within the block)
+pub fun set(name: letvar<<let|e>,a>, binding: () -> <let|e> a, f: () -> <let|e2> b): <let|e2> b
+  with override<let>
+    fun unsafe-binding(query)
+      if query.uid == name.uid then unsafe-cast(binding) else unsafe-binding(query)
+    fun unsafe-bindings()
+      Cons((name.uid, unsafe-cast(binding)), unsafe-bindings())
+  f()
+
+extern unsafe-cast(x: a): b
+  inline "#1"
+
+// used by test suite to allow bindings defined in an outer group to
+// take effect within test body
+pub fun capture-bindings(): let ((() -> <let|e> a) -> <let|e> a)
+  val bindings = unsafe-bindings()
+  fun restore(f: () -> <let|e> a): <let|e> a
+    with override<let>
+      fun unsafe-bindings() bindings
+      fun unsafe-binding(query)
+        val binding = bindings.find(fn(b) b.fst == query.uid)
+        match binding
+          Just(b) -> unsafe-cast(b.snd)
+          Nothing -> unsafe-binding(query)
+    f()
+  restore
+

--- a/std/test/test.kk
+++ b/std/test/test.kk
@@ -13,6 +13,7 @@ import std/num/ddouble
 import std/num/float64
 import std/num/int64
 import std/core-extras
+import std/let
 
 pub alias test-reporter<e> = (action: () -> <test-report|e> ()) -> e ()
 
@@ -187,10 +188,12 @@ pub fun hint(value: string): expect ()
 // (the call to `effectful-test`) and test execution (the call to `run-tests`).
 //
 // Use `test` function where possible, as it ensures that the test body doesn't accidentally make use of an inherited effect.
-pub fun effectful-test<e>(name: string, f: () -> <expect,random,io|e> (), ?kk-module: string, ?kk-line: string): <test<<io|e>>|e> ()
-  register-test(Test-identity(gen-test-id(), current-scope, name, Location(?kk-module, ?kk-line)), f)
+pub fun effectful-test<e>(name: string, f: () -> <expect,let,random,io|e> (), ?kk-module: string, ?kk-line: string): <let,test<<let,io|e>>|e> ()
+  val apply-bindings = let/capture-bindings()
+  fun test-body() apply-bindings(f)
+  register-test(Test-identity(gen-test-id(), current-scope, name, Location(?kk-module, ?kk-line)), test-body)
 
-pub fun test(name: string, f: () -> <expect,io,random> (), ?kk-module: string, ?kk-line: string): test<io> ()
+pub fun test(name: string, f: () -> <expect,let,io,random> (), ?kk-module: string, ?kk-line: string): <let,test<<let,io>>> ()
   effectful-test(name, f)
 
 // Property test:
@@ -203,7 +206,7 @@ pub fun prop-test(
   count: int = default-sample-count,
   ?kk-module: string,
   ?kk-line: string
-): <test<<io>>,io> ()
+): <let,test<<let,io>>,io> ()
   fun run()
     val seed-value = next-seed()
     with pseudo-random(seed-value)

--- a/test/let-test.kk
+++ b/test/let-test.kk
@@ -1,0 +1,98 @@
+import std/test
+import std/let
+import std/num/random
+
+struct person
+  name: string
+  age: int
+
+fun person/show(person: person)
+  "Person " ++ person.name ++ " is " ++ person.age.show
+
+fun person/(==)(a: person, b: person)
+  (
+    a.name == b.name &&
+    a.age == b.age
+  )
+
+fun suite(): <test<<io,let>>,let,io> ()
+  test("vars with default")
+    val name = let { "adam" }
+    val age = let { 1 }
+    val person = let { Person(name.get, age.get) }
+    expect(Person("adam", 1)) { person.get }
+
+    with age.set { 2 }
+    expect(Person("adam", 2)) { person.get }
+
+    with name.set { "ben" }
+    with age.set { 3 }
+    expect(Person("ben", 3)) { person.get }
+
+  test("undefined vars")
+    val tag = let-undefined()
+    val err = try { tag.get }
+    expect(True) { err.is-error }
+
+    with tag.set { "foo" }
+    expect("foo") { tag.get }
+  
+  test("type of letvar")
+    // TODO: it's currently not possible to write the correct type, which should be:
+    // val v: letvar<<let>, int> = let { 1 }
+    val v = let { 1 }
+    expect(1) { v.get }
+  
+  group("nested scopes")
+    val scope = let { "default" }
+    test("test inherits from outer scope")
+      expect("default") { scope.get }
+
+    group("inner scope")
+      with scope.set { "group" }
+      test("test inherits from inner scope")
+        expect("group") { scope.get }
+
+      test("group scope can be overridden within test")
+        with scope.set { "test" }
+        expect("test") { scope.get }
+
+  group("documentation example")
+    // NOTE: keep in sync with example in let.kk
+    val isbn = let { "978-1-56619-909-4" }
+    val title = let { "The Best Book" }
+    val author = let { "Eric Carle" }
+    val book = let { Book(isbn.get, author.get, title.get) }
+    val books = let { [book.get] }
+    fun shelves() stack-shelves(books.get)
+
+    group("a long title")
+      with title.set { "I can't believe this title is so long did nobody think of that?" }
+
+      test("it should fit on a single shelf")
+        expect(1) { shelves().length }
+
+    group("ten books")
+      with books.set
+        val b = book.get
+        [b, b, b, b, b, b, b, b, b, b]
+
+      test("requires two shelves")
+        expect(2) { shelves().length }
+
+fun main() run-tests(suite)
+
+// utilities to make documentation example work
+struct book
+  isbn: string
+  author: string
+  title: string
+
+struct shelf(books: list<book>)
+
+fun stack-shelves(books)
+  val shelf = books.list/take(5)
+  if books.length > 5 then
+    Cons(shelf, stack-shelves(books.drop(5)))
+  else
+    [shelf]


### PR DESCRIPTION
This effect is also added to the set of effects used in tests, with support for inheriting variables from the group where a test is defined.

I've included fairly extensive doc-comments to help explain the motivation and use cases :)