### PR TITLE
A quick fix for command construction in detect.kk

### DIFF
--- a/std/test/detect.kk
+++ b/std/test/detect.kk
@@ -30,7 +30,7 @@ fun main()
     // basic escaping effort, TODO a version of run-system that accepts a list of args
     "'" ++ arg ++ "'"
   .join(" ")
-  val cmd = "koka -e " ++ test-path.string ++ " -- " ++ args
+  val cmd = "koka -e " ++ test-path.string ++ " " ++ args
 
   println(" + " ++ cmd)
   val status = run-system(cmd)


### PR DESCRIPTION
Instead of guarding args passed to `koka -e` via `--`, pass all args as is. If a user needs to pass cli args to suites, they can use `--` explicitly

Unblocks #43 