### PR TITLE
Add incremental parsing to std/text/parse

### DIFF
--- a/std/text/parse-inc.kk
+++ b/std/text/parse-inc.kk
@@ -1,0 +1,271 @@
+/*---------------------------------------------------------------------------
+  Copyright 2020-2021, Microsoft Research, Daan Leijen.
+
+  This is free software; you can redistribute it and/or modify it under the
+  terms of the Apache License, Version 2.0. A copy of the License can be
+  found in the LICENSE file at the root of this distribution.
+---------------------------------------------------------------------------*/
+
+/* Parser combinators
+*/
+module std/text/parse-inc
+
+import std/core/undiv
+
+// A function that parses some input into a result `a`.
+pub alias parser<e,a> = () -> <parse|e> a
+
+type parse-length
+  Exactly( n: int )
+  AtLeast( n: int )
+
+// Management of the branching alternatives for parsing an input string.
+pub effect parse
+  // Advance the input if and only if it currently satisfies `pred`.
+  // Further parsers continue with the slice it returns.
+  // 
+  // See also `satisfy-fail` which invokes `fail` when `pred` returns `Nothing`.
+  fun satisfy( pred : sslice -> total maybe<(a,sslice)>, len : parse-length = AtLeast(0) ) : maybe<a>
+  // Fails the current branch of parsing.
+  final ctl fail(msg : string) : a
+  // Pick allows the user to try different parses.
+  // Handlers usually resume up to twice with `True` and `False`.
+  ctl pick() : bool
+  // The current position of parse on the input.
+  fun current-input() : sslice
+
+// Result of a parse
+pub type parse-error<a>
+  ParseOk( result: a, rest : sslice )
+  ParseError( msg : string, rest : sslice )
+
+pub fun starts-with( s : string, p : () -> parse a )  : maybe<(a,sslice)>
+  match s.slice.parse(p)
+    ParseOk(x,rest) -> Just((x,rest))
+    _               -> Nothing
+
+pub fun maybe( perr : parse-error<a> ) : maybe<a>
+  perr.either.maybe
+
+pub fun either( perr : parse-error<a> ) : either<string,a>
+  match perr
+    ParseOk(x,_) -> Right(x)
+    ParseError(msg,_) -> Left(msg)
+
+pub fun parse-eof( input : sslice, p : () -> <parse|e> a) : e parse-error<a>
+  parse(input)
+    val x = p()
+    eof()
+    x
+
+// Parses `input0` with `p`.
+//
+// This implements the `pick` ctl using a depth-first search,
+//   short-circuiting if the `True` branch succeeds.
+// If both alternatives of a `pick` invoke `fail`, 
+//   the first error will be returned.
+pub fun parse( input0 : sslice, p : () -> <parse|e> a, get-next : () -> <div|e> maybe<string> = { Nothing } ) : e parse-error<a>
+  var input-buf := input0.string
+  var input := input-buf.slice
+
+  handle p
+    return(x)
+      ParseOk(x,input)
+
+    fun current-input()
+      input
+
+    final ctl fail(msg)
+      ParseError(msg,input)
+
+    fun satisfy(pred, pl : parse-length)
+      fun go()
+        val input-count = input.count
+        match (pred(input), pl)
+          // Input is too short, try to get more
+          (_, pl) | pl.n > input-count -> match get-next()
+            Nothing -> Nothing
+            Just(next) ->
+              input-buf := input-buf ++ next
+              input := input-buf.slice.advance(input.before.count)
+              go()
+          // We parsed something but there may be more
+          (Just((x,cap)), AtLeast(_)) | cap.count == 0 -> match get-next()
+            Nothing -> { input := cap; Just(x) }
+            Just(next) ->
+              input-buf := input-buf ++ next
+              input := input-buf.slice.advance(input.before.count)
+              go()
+          // We're done parsing
+          (Nothing, _) -> Nothing
+          (Just((x,cap)), _) -> { input := cap; Just(x) }
+      pretend-no-div
+        go()
+
+    ctl pick()
+      val save = input;
+      match resume(True)
+        ParseOk(x1,rest1) -> ParseOk(x1,rest1)
+        err1 ->
+          input := input-buf.slice.advance(save.before.count)
+          match resume(False)   // todo: limit lookahead?
+            ParseOk(x2,rest2) -> ParseOk(x2,rest2)
+            _err2 -> err1  // todo: merge or pick closest?
+
+
+pub fun (||)( p1 : parser<e,a>, p2 : parser<e,a> ) : <parse|e> a
+  if pick() then p1() else p2()
+
+pub fun optional( default : a, p : parser<e,a> ) : <parse|e> a
+  p || (fn() default)
+
+pub fun choose( ps : list<parser<e,a>> ) : <parse|e> a
+  match ps
+    Nil         -> fail("no further alternatives")
+    Cons(p,Nil) -> p()
+    Cons(p,pp)  -> if pick() then p() else choose(pp)
+
+pub fun satisfy-fail( msg : string, pred : sslice -> maybe<(a,sslice)>, pl : parse-length = AtLeast(0) ) : parse a
+  match satisfy(pred, pl)
+    Nothing -> fail(msg)
+    Just(x) -> x
+
+pub fun eof() : parse ()
+  match satisfy( fn(s) if s.is-empty then Just(((),s)) else Nothing, Exactly(0) )
+    Nothing -> fail("expecting end-of-input")
+    Just    -> ()
+
+pub fun char-is( msg :string, pred : char -> bool ) : parse char
+  fun go(slice)
+    match slice.next
+      Just((c,rest)) | pred(c) -> Just((c,rest))
+      _ -> Nothing
+  satisfy-fail(msg, go, Exactly(1))
+
+
+fun next-while0( slice : sslice, pred : char -> bool, acc : list<char> ) : (list<char>,sslice)
+  match slice.next
+    Just((c,rest)) | pred(c) -> next-while0(pretend-decreasing(rest), pred, Cons(c,acc) )
+    _ -> (acc.reverse,slice)
+
+
+pub fun chars-are( msg :string, pred : char -> bool ) : parse list<char>
+  fun go(slice)
+    match slice.next-while0(pred,[])
+      ([],_)    -> Nothing
+      (xs,rest) -> Just((xs,rest))
+  satisfy-fail(msg, go, AtLeast(1))
+
+fun next-match( slice : sslice, cs : list<char> ) : maybe<sslice>
+  match cs
+    Nil -> Just(slice)
+    Cons(c,cc) -> match slice.next
+      Just((d,rest)) | c==d -> rest.next-match( cc )
+      _ -> Nothing
+
+pub fun pstring( s : string ) : parse string
+  fun go(slice)
+    match slice.next-match(s.list)
+      Just(rest) -> Just((s,rest))
+      Nothing    -> Nothing
+  satisfy-fail(s, go, Exactly(s.count))
+
+pub fun char( c : char ) : parse char
+  char-is( show(c), fn(c0) c == c0  )
+
+pub fun no-digit() : parse char
+  char-is("not a digit", fn(c) !c.is-digit )
+
+pub fun digit() : parse int
+  val c = char-is("digit", is-digit)
+  (c - '0').int
+
+pub fun alpha() : parse char
+  char-is("alpha", is-alpha)
+
+pub fun alpha-num() : parse char
+  char-is("alpha-num", is-alpha-num)
+
+pub fun white() : parse char
+  char-is("", is-white)
+
+pub fun whitespace() : parse string
+  chars-are("", is-white).string
+
+pub fun whitespace0() : parse string
+  optional("", whitespace)
+
+pub fun digits() : parse string
+  chars-are("digit", is-digit ).string
+
+pub fun digits0() : parse string
+  optional("0", digits)
+
+pub fun sign() : parse bool
+  val c = one-of-or("+-", '+')
+  (c=='-')
+
+pub fun pnat() : parse int
+  digits().parse-int.default(0)
+
+pub fun pint() : parse int
+  val neg = sign()
+  val i = pnat()
+  if neg then ~i else i
+
+pub fun none-of( chars : string ) : parse char
+  char-is("", fn(c) !chars.contains(c.string) )
+
+pub fun none-of-many1( chars : string ) : parse string
+  chars-are("", fn(c) !chars.contains(c.string)).string
+
+pub fun one-of( chars : string ) : parse char
+  char-is(chars, fn(c) chars.contains(c.string))
+  // chars.list.map(fn(c){ (fn(){ char(c) } ) }).choose
+
+fun many-acc( p : parser<e,a>, acc : list<a> ) : <parse|e> list<a>
+  (fn() val x = p() in many-acc(pretend-decreasing(p),Cons(x,acc))) || (fn() acc.reverse)
+
+// The `many` combinator parses `p` until it fails, returning a list of the results of `p`.
+// The `many` combinator is non-divergent only when `p` always consumes input or `fail`s.
+pub fun many( p : parser<e,a> ) : <parse|e> list<a>
+  many-acc(p,[])
+
+// The `many1` combinator parses `p` at least once and then until it fails, returning a list of the results of `p`.
+// The `many1` combinator is non-divergent only when `p` always consumes input or `fail`s.
+pub fun many1( p : parser<e,a> ) : <parse|e> list<a>
+  Cons(p(), many(p))
+
+// The `sep-by` parses zero or more occurrences of `p`, separated by `sep`. Returns a list of the results of `p`.
+// The `sep-by` combinator is non-divergent only when `p` always consumes input or `fail`s.
+pub fun sep-by( p : parser<e,a>, sep : parser<e,b> ) : <parse|e> list<a>
+  optional([]){ sep-by1(p, sep) }
+
+// The `sep-by1` parses one or more occurrences of `p`, separated by `sep`. Returns a list of the results of `p`.
+// The `sep-by1` combinator is non-divergent only when `p` always consumes input or `fail`s.
+pub fun sep-by1( p : parser<e,a>, sep : parser<e,b> ) : <parse|e> list<a>
+  Cons(p(), many{ sep(); p(); })
+
+fun count-acc( n : int, acc : list<a>, p : parser<e,a> ) : <parse|e> list<a>
+  if n <= 0 then acc.reverse else
+    val x = p()
+    count-acc(pretend-decreasing(n - 1), Cons(x,acc), p)
+
+
+pub fun count( n : int, p : parser<e,a> ) : <parse|e> list<a>
+  count-acc(n, [], p)
+
+pub fun one-of-or( chars : string, default : char ) : parse char
+  optional(default){ one-of(chars) }
+
+//val rx-float	= regex(r"^([\-\+])?(\d+(?:\.\d+)?(?:[eE][\-\+]\d+)?)$")
+//val rx-hexfloat	= regex(r"^([\-\+]?0[xX][0-9a-fA-F]+)(?:\.([0-9a-fA-F]+))?(?:[pP]([\-\+]?\d+))?$")
+
+pub fun hex-digits() : parse string
+  chars-are("digit", is-hex-digit ).string
+
+/*
+pub fun test(s : string, x : a, p : () -> parse a ) : a
+  parse-eof(s.slice,p).maybe.default(x)
+*/
+


### PR DESCRIPTION
This PR extends [`std/text/parse`](https://github.com/koka-lang/koka/blob/dev/lib/std/text/parse.kk), it can (and should) be diffed against it.

We allow the user to pass a `get-next` function to `parse`, which tries to perform some sort of I/O (i.e. reading from a file or a socket) to get more input when needed. We also annotate each call to `satisfy` (and `satisfy-length`) with a `parse-length`, so that we know when it's useful to try to get more input. Here is the intended logic:

- If the input is too short for what we're trying to parse, we try to get more input and retry parsing
- If we successfully parsed until the end of the input, but what we're parsing can have unbounded length (see `chars-are`), we try to get more input and retry parsing
- If we're in none of the cases above, we fall back to the default behavior

There are some points for which I'd like to gather some opinions:

- The changes were made so that they don't break user code: the additional arguments to `satisfy`, `satisfy-fail` and `parse` are optional (since all of them are public). Maybe it's OK to break the API, but I don't see what could be the benefits.
- `input` is now a slice over the internal `input-buf`, which may be extended with `get-next` output. I think initializing `input-buf` to `input0.string` immediately is fine, since a user would most likely provide a slice over an entire string anyway, which would make `input0.string` O(1).
- However `input := input-buf.slice.advance(save.before.count)` in `pick` (which transposes `input` onto the new, extended `input-buf`) has a performance on existing, non-incremental parsers. To make this O(1), we would need something like `fun transpose(ss: sslice, s: string): sslice` in `std/core/sslice`. This would also be helpful in `satisfy` which has the same problem, however it feels very specific and unsafe (the only safe case is if `s` is an extended version of the string pointed to by `ss`).
- `go()` runs under `pretend-no-div` so that `parse` doesn't get the `div` effect. This assumes the stream of input given by `get-next` will end. I think this is fine, since `get-next` will have an effect of his own (like `net`).