### PR TITLE
use try instead of deprecated catch

### DIFF
--- a/std/core-extras.kk
+++ b/std/core-extras.kk
@@ -18,7 +18,7 @@ pub fun pretend-not-reachable(?kk-file-line: string): b
 
 pub fun no-effect-top(a: () -> pure a, ?kk-file-line: string): a
   with pretend-no-div
-  catch(a) fn(err)
+  try(a) fn(err)
     impossible(err.show)
 
 pub fun list/and(l: list<bool>): bool


### PR DESCRIPTION
Fixes https://github.com/koka-community/std/commit/d987e13f58d29531ad1460d5f1810b3898ee30c4#r175088233