### PR TITLE
test: update kk-line interface for koka v3.2.3

### DIFF
--- a/std/test/test.kk
+++ b/std/test/test.kk
@@ -42,11 +42,11 @@ pub effect expect
   fun test-iteration(): () // declare a new iteration
 
 abstract value struct location
-  mod: string
-  line: string
+  file: string
+  line: int
   
 pub fun location/show(l: location): string
-  l.mod ++ ":" ++ l.line
+  l.file ++ ":" ++ l.line.show
 
 pub struct test-scope
   scope-id: int
@@ -98,15 +98,16 @@ pub fun show(expectation: expectation): div string
     Left(msg) -> "Expectation failed ("++ location ++ ")\n" ++ msg
     Right(()) -> "Expectation succeeded ( " ++ location ++ ")"
 
-pub fun fail(assertion: string = "", ?kk-line: string, ?kk-module: string)
+pub fun fail(assertion: string = "", ?kk-file: string, ?kk-line: int)
   test-expect(
     Left("Assertion failed" ++ (if assertion == "" then "" else ": " ++ assertion)),
-    ?kk-module ++ ":" ++ ?kk-line
+    ?kk-file,
+    ?kk-line
   )
 
 // base expectation API
-pub fun api/test-expect(result: either<string,()>, ?kk-line: string, ?kk-module: string)
-  test-expect(Expectation(result, ?kk-module ++ ":" ++ ?kk-line))
+pub fun api/test-expect(result: either<string,()>, ?kk-file: string, ?kk-line: int)
+  test-expect(Expectation(result, ?kk-file ++ ":" ++ ?kk-line.show))
 
 fun but-raised(e: exception): string
   "but raised: " ++ e.show
@@ -114,7 +115,7 @@ fun but-raised(e: exception): string
 // Expects a computation to return a value
 //
 // The expected type must have an `(==)` function as well as a `show` function defined for it
-pub fun expect(expected: a, run: () -> <exn,expect,div|e> a, details: string = "", ?(==): (a,a) -> div bool, ?show: (a) -> div string, ?kk-line: string, ?kk-module: string): <expect,div|e> ()
+pub fun expect(expected: a, run: () -> <exn,expect,div|e> a, details: string = "", ?(==): (a,a) -> div bool, ?show: (a) -> div string, ?kk-file: string, ?kk-line: int): <expect,div|e> ()
   val actual = try({run()})
   val expected-str = "expected:" ++ expected.show
   val result = match actual
@@ -124,12 +125,12 @@ pub fun expect(expected: a, run: () -> <exn,expect,div|e> a, details: string = "
       else
         Left(expected-str ++ "\n     got: " ++ a.show)
     Error(e) -> Left(expected-str ++ "\n" ++ but-raised(e))
-  test-expect(result, ?kk-module, ?kk-line)
+  test-expect(result, ?kk-file, ?kk-line)
 
 // Expect a predicate over some value to return true.
 // Assertion is an optional string to describe the predicate.
 // On error, the value is printed.
-pub fun expect-that(predicate: (a) -> <exn,div|e> bool, run: () -> <exn,div,expect|e> a, assertion: string = "", ?show: (a) -> div string, ?kk-line: string, ?kk-module: string): <expect,div|e> ()
+pub fun expect-that(predicate: (a) -> <exn,div|e> bool, run: () -> <exn,div,expect|e> a, assertion: string = "", ?show: (a) -> div string, ?kk-file: string, ?kk-line: int): <expect,div|e> ()
   val value = try({run()})
   val expected-str = "expected: " ++ (if assertion == "" then "predicate to pass" else assertion)
   val result = match value
@@ -142,15 +143,15 @@ pub fun expect-that(predicate: (a) -> <exn,div|e> bool, run: () -> <exn,div,expe
         Error(e) -> Left(base ++ "\nbut predicate raised: " ++ e.show)
     Error(e) ->
       Left(expected-str ++ "\n" ++ but-raised(e))
-  test-expect(result, ?kk-module, ?kk-line)
+  test-expect(result, ?kk-file, ?kk-line)
 
 // group of tests, requires (and overrides) test-scope
-pub fun group(name: string, f: () -> <test<e>|e> (), ?kk-module: string, ?kk-line: string): <test<e>|e> ()
+pub fun group(name: string, f: () -> <test<e>|e> (), ?kk-file: string, ?kk-line: int): <test<e>|e> ()
   val scope = Test-scope(
     scope-id = gen-test-id(),
     parent = current-scope,
     scope-name = name,
-    location = Location(?kk-module, ?kk-line)
+    location = Location(?kk-file, ?kk-line)
   )
   with override<some<e> test<e>>
     val default-sample-count = default-sample-count
@@ -168,10 +169,10 @@ pub fun hint(value: string): expect ()
 // (the call to `effectful-test`) and test execution (the call to `run-tests`).
 //
 // Use `test` function where possible, as it ensures that the test body doesn't accidentally make use of an inherited effect.
-pub fun effectful-test<e>(name: string, f: () -> <expect,random,io|e> (), ?kk-module: string, ?kk-line: string): <test<<io|e>>|e> ()
-  register-test(Test-identity(gen-test-id(), current-scope, name, Location(?kk-module, ?kk-line)), f)
+pub fun effectful-test<e>(name: string, f: () -> <expect,random,io|e> (), ?kk-file: string, ?kk-line: int): <test<<io|e>>|e> ()
+  register-test(Test-identity(gen-test-id(), current-scope, name, Location(?kk-file, ?kk-line)), f)
 
-pub fun test(name: string, f: () -> <expect,io,random> (), ?kk-module: string, ?kk-line: string): test<io> ()
+pub fun test(name: string, f: () -> <expect,io,random> (), ?kk-file: string, ?kk-line: int): test<io> ()
   effectful-test(name, f)
 
 // Property test:
@@ -182,8 +183,8 @@ pub fun prop-test(
   name,
   action: () -> <random,expect,io> (),
   count: int = default-sample-count,
-  ?kk-module: string,
-  ?kk-line: string
+  ?kk-file: string,
+  ?kk-line: int
 ): <test<<io>>,io> ()
   fun run()
     val seed-value = next-seed()
@@ -250,7 +251,7 @@ pub fun execute(summary: suite-summary, test: test-case<<io|e>>, seed: maybe<int
           resume(())
   }
   with mask<test-report>
-  expect((), ?kk-line=tid.location.line, ?kk-module=tid.location.mod)
+  expect((), ?kk-file=tid.location.file, ?kk-line=tid.location.line)
     with mask<local>
     (test.body)()
   test-result()


### PR DESCRIPTION
`kk-line` is now an `int`, not a string (https://github.com/koka-lang/koka/commit/c6d906db0914235e1d878cd404f9eb50a088eb64)

also use kk-file over kk-mod to get better source code locations