### PR TITLE
test effect: remove extra effects from definition time

### DIFF
--- a/std/test/test.kk
+++ b/std/test/test.kk
@@ -146,7 +146,7 @@ pub fun expect-that(predicate: (a) -> <exn,div|e> bool, run: () -> <exn,div,expe
   test-expect(result, ?kk-file, ?kk-line)
 
 // group of tests, requires (and overrides) test-scope
-pub fun group(name: string, f: () -> <test<e>|e> (), ?kk-file: string, ?kk-line: int): <test<e>|e> ()
+pub fun group(name: string, f: () -> <test<e>> (), ?kk-file: string, ?kk-line: int): <test<e>> ()
   val scope = Test-scope(
     scope-id = gen-test-id(),
     parent = current-scope,
@@ -169,7 +169,7 @@ pub fun hint(value: string): expect ()
 // (the call to `effectful-test`) and test execution (the call to `run-tests`).
 //
 // Use `test` function where possible, as it ensures that the test body doesn't accidentally make use of an inherited effect.
-pub fun effectful-test<e>(name: string, f: () -> <expect,random,io|e> (), ?kk-file: string, ?kk-line: int): <test<<io|e>>|e> ()
+pub fun effectful-test<e>(name: string, f: () -> <expect,random,io|e> (), ?kk-file: string, ?kk-line: int): <test<<io|e>>> ()
   register-test(Test-identity(gen-test-id(), current-scope, name, Location(?kk-file, ?kk-line)), f)
 
 pub fun test(name: string, f: () -> <expect,io,random> (), ?kk-file: string, ?kk-line: int): test<io> ()
@@ -185,7 +185,7 @@ pub fun prop-test(
   count: int = default-sample-count,
   ?kk-file: string,
   ?kk-line: int
-): <test<<io>>,io> ()
+): <test<<io>>> ()
   fun run()
     val seed-value = next-seed()
     with pseudo-random(seed-value)


### PR DESCRIPTION
Replacement for https://github.com/koka-community/std/pull/53. I think this makes more sense. `effectful-test` no longer requires the effect at definition time, it just produces a test case that requires the effect. That matches `test`, which doesn't require `io` but produces a `test<io>`.

It was always a little confusing that you could theoretically use one `async` handler at definition time but a different one at execution time.

And now `group` doesn't need to assume `io`, it just adopts whatever test types are used in its body.

I originally thought it might be important to allow additional effects in `group` bodies, and maybe we'll need to support that later. But I don't know of a use case yet, so let's not guess.